### PR TITLE
Remove CeWL & Ruby tools; revamp tools UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,10 @@ lint:
 	@golangci-lint run ./...
 	@echo "✅ Lint passed"
 
-## setup: Build, install chaathan, then install all required external tools
-setup: install
+## setup: Install all required external tools
+setup: build
 	@echo "Running tool setup..."
-	@$(BINARY_NAME) setup
+	@./$(BINARY_NAME) setup
 	@echo "✅ Setup complete"
 
 ## tools-check: Check which external tools are installed

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ git clone https://github.com/vishnu303/chaathan-flow.git
 cd chaathan-flow
 
 # One-command setup: builds, installs to /usr/local/bin, installs all tools
-make setup
+make all
 
 # Or step by step:
 make build          # Build binary
 make install        # Install to /usr/local/bin
-chaathan setup      # Install all external tools
+make setup          # Install all external tools
 ```
 
 **Requirements:** Go 1.21+, Git, Linux
@@ -283,12 +283,12 @@ chaathan setup          # install everything
 ```bash
 make build          # build binary
 make install        # build + install to /usr/local/bin
-make setup          # build + install + install all tools (one-stop)
+make setup          # build + install all tools
 make clean          # remove build artifacts
 make test           # run tests
 make vet            # static analysis
 make tools-check    # check installed tools
-make all            # build + install + setup
+make all            # build + install + setup (one-stop)
 ```
 
 ## Continuous Monitoring

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -93,12 +93,11 @@ func captureCommandOutput(cmd *exec.Cmd, toolName string) error {
 var setupCmd = &cobra.Command{
 	Use:   "setup",
 	Short: "Install all dependency tools",
-	Long: `Installs the 28+ tools required for native execution mode.
+	Long: `Installs the tools required for native execution mode.
 
 Categories:
   - Go tools:     subfinder, httpx, nuclei, katana, naabu, etc.
-  - Python tools: sublist3r, subdomainizer, linkfinder, uro
-  - Ruby tools:   cewl (Custom Word List generator)
+  - Python tools: sublist3r, subdomainizer, linkfinder, arjun
   - From source:  massdns (high-performance DNS resolver)
 
 Already-installed tools are skipped automatically.
@@ -117,32 +116,30 @@ func init() {
 // ── Tool definitions ─────────────────────────────────────────────────────────
 
 var goTools = []struct {
-	name     string
-	url      string
-	needsCGO bool
+	name string
+	url  string
 }{
-	{"subfinder", "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest", false},
-	{"amass", "github.com/owasp-amass/amass/v4/...@latest", false},
-	{"nuclei", "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest", true},
-	{"httpx", "github.com/projectdiscovery/httpx/cmd/httpx@latest", false},
-	{"naabu", "github.com/projectdiscovery/naabu/v2/cmd/naabu@latest", true},
-	{"assetfinder", "github.com/tomnomnom/assetfinder@latest", false},
-	{"gau", "github.com/lc/gau/v2/cmd/gau@latest", false},
-	{"metabigor", "github.com/j3ssie/metabigor@latest", false},
-	{"shuffledns", "github.com/projectdiscovery/shuffledns/cmd/shuffledns@latest", false},
-	{"anew", "github.com/tomnomnom/anew@latest", false},
-	{"dnsx", "github.com/projectdiscovery/dnsx/cmd/dnsx@latest", false},
-	{"katana", "github.com/projectdiscovery/katana/cmd/katana@latest", false},
-	{"ffuf", "github.com/ffuf/ffuf/v2@latest", false},
-	{"gospider", "github.com/jaeles-project/gospider@latest", false},
-	{"waybackurls", "github.com/tomnomnom/waybackurls@latest", false},
-	{"github-subdomains", "github.com/gwen001/github-subdomains@latest", false},
-	// --- Phase 3: New tools ---
-	{"alterx", "github.com/projectdiscovery/alterx/cmd/alterx@latest", false},
-	{"subjack", "github.com/haccer/subjack@latest", false},
-	{"dalfox", "github.com/hahwul/dalfox/v2@latest", false},
-	{"tlsx", "github.com/projectdiscovery/tlsx/cmd/tlsx@latest", false},
-	{"uncover", "github.com/projectdiscovery/uncover/cmd/uncover@latest", false},
+	{"subfinder", "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest"},
+	{"amass", "github.com/owasp-amass/amass/v4/...@latest"},
+	{"nuclei", "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest"},
+	{"httpx", "github.com/projectdiscovery/httpx/cmd/httpx@latest"},
+	{"naabu", "github.com/projectdiscovery/naabu/v2/cmd/naabu@latest"},
+	{"assetfinder", "github.com/tomnomnom/assetfinder@latest"},
+	{"gau", "github.com/lc/gau/v2/cmd/gau@latest"},
+	{"metabigor", "github.com/j3ssie/metabigor@latest"},
+	{"shuffledns", "github.com/projectdiscovery/shuffledns/cmd/shuffledns@latest"},
+	{"anew", "github.com/tomnomnom/anew@latest"},
+	{"dnsx", "github.com/projectdiscovery/dnsx/cmd/dnsx@latest"},
+	{"katana", "github.com/projectdiscovery/katana/cmd/katana@latest"},
+	{"ffuf", "github.com/ffuf/ffuf/v2@latest"},
+	{"gospider", "github.com/jaeles-project/gospider@latest"},
+	{"waybackurls", "github.com/tomnomnom/waybackurls@latest"},
+	{"github-subdomains", "github.com/gwen001/github-subdomains@latest"},
+	{"alterx", "github.com/projectdiscovery/alterx/cmd/alterx@latest"},
+	{"subjack", "github.com/haccer/subjack@latest"},
+	{"dalfox", "github.com/hahwul/dalfox/v2@latest"},
+	{"tlsx", "github.com/projectdiscovery/tlsx/cmd/tlsx@latest"},
+	{"uncover", "github.com/projectdiscovery/uncover/cmd/uncover@latest"},
 }
 
 var pyTools = []struct {
@@ -165,12 +162,6 @@ var pyScripts = []struct {
 	{"subdomainizer", "https://github.com/nsonaniya2010/SubDomainizer.git", "SubDomainizer.py"},
 }
 
-var rubyTools = []struct {
-	name    string
-	gemName string
-}{
-	{"cewl", "cewl"},
-}
 
 // ── Main setup entrypoint ────────────────────────────────────────────────────
 
@@ -203,12 +194,6 @@ func runSetup(cmd *cobra.Command, args []string) {
 
 	// Python tools
 	i, s, f = installPythonToolsSection()
-	totalInstalled += int32(i)
-	totalSkipped += int32(s)
-	totalFailed += int32(f)
-
-	// Ruby tools
-	i, s, f = installRubyToolsSection()
 	totalInstalled += int32(i)
 	totalSkipped += int32(s)
 	totalFailed += int32(f)
@@ -305,9 +290,8 @@ func runSysCmd(name string, args ...string) error {
 func installGoToolsSection() (installed, skipped, failed int) {
 	// Filter already-installed tools
 	var toInstall []struct {
-		name     string
-		url      string
-		needsCGO bool
+		name string
+		url  string
 	}
 	var skippedCount int
 	for _, t := range goTools {
@@ -340,18 +324,13 @@ func installGoToolsSection() (installed, skipped, failed int) {
 
 	for _, t := range toInstall {
 		wg.Add(1)
-		go func(tool struct {
-			name     string
-			url      string
-			needsCGO bool
-		}) {
+		go func(tool struct{ name, url string }) {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
 			tracker.Start(tool.name)
-			err := installGoTool(tool.name, tool.url, tool.needsCGO)
-			if err != nil {
+			if err := installGoTool(tool.name, tool.url); err != nil {
 				tracker.Fail(tool.name, err.Error())
 			} else {
 				tracker.Complete(tool.name)
@@ -366,18 +345,11 @@ func installGoToolsSection() (installed, skipped, failed int) {
 	return i, skippedCount, f
 }
 
-func installGoTool(name, url string, needsCGO bool) error {
+func installGoTool(name, url string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "go", "install", "-v", url)
-
-	if needsCGO {
-		cmd.Env = append(os.Environ(), "CGO_ENABLED=1")
-	} else {
-		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
-	}
-
 	return captureCommandOutput(cmd, name)
 }
 
@@ -493,69 +465,6 @@ func installPythonToolsSection() (installed, skipped, failed int) {
 			if err := os.WriteFile(dst, input, 0755); err != nil {
 				tracker.Fail(tool.name, "write failed")
 				return
-			}
-			tracker.Complete(tool.name)
-		}(t)
-	}
-
-	wg.Wait()
-	tracker.StopSpinner()
-
-	i, _, f := tracker.Stats()
-	return i, skippedCount, f
-}
-
-// ── Ruby Tools ───────────────────────────────────────────────────────────────
-
-func installRubyToolsSection() (installed, skipped, failed int) {
-	if _, err := exec.LookPath("gem"); err != nil {
-		progress.Section("Ruby Tools", "")
-		progress.ItemInfo("gem not found — skipping")
-		return 0, 0, 0
-	}
-
-	var toInstall []struct{ name, gem string }
-	var skippedCount int
-	for _, t := range rubyTools {
-		if _, err := exec.LookPath(t.name); err == nil {
-			skippedCount++
-			continue
-		}
-		toInstall = append(toInstall, struct{ name, gem string }{t.name, t.gemName})
-	}
-
-	detail := ""
-	if skippedCount > 0 {
-		detail = fmt.Sprintf("%d to install, %d already installed", len(toInstall), skippedCount)
-	} else {
-		detail = fmt.Sprintf("%d to install", len(toInstall))
-	}
-	progress.Section("Ruby Tools", detail)
-
-	if len(toInstall) == 0 {
-		progress.ItemInfo("Nothing to do")
-		return 0, skippedCount, 0
-	}
-
-	tracker := progress.NewTracker(len(toInstall))
-	tracker.RunSpinner()
-
-	var wg sync.WaitGroup
-	for _, t := range toInstall {
-		wg.Add(1)
-		go func(tool struct{ name, gem string }) {
-			defer wg.Done()
-			tracker.Start(tool.name)
-
-			// Try without sudo first
-			cmd := exec.Command("gem", "install", tool.gem)
-			if err := captureCommandOutput(cmd, tool.name); err != nil {
-				// Retry with sudo
-				cmd = exec.Command("sudo", "gem", "install", tool.gem)
-				if err := captureCommandOutput(cmd, tool.name+" (sudo)"); err != nil {
-					tracker.Fail(tool.name, err.Error())
-					return
-				}
 			}
 			tracker.Complete(tool.name)
 		}(t)

--- a/cli/tools_cmd.go
+++ b/cli/tools_cmd.go
@@ -2,9 +2,8 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
-	"text/tabwriter"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -28,6 +27,7 @@ var allTools = []struct {
 	// DNS & Resolution
 	{"dnsx", "DNS", "DNS resolution & record lookup", true},
 	{"shuffledns", "DNS", "DNS brute-force with massdns", false},
+	{"massdns", "DNS", "High-performance DNS resolver (from source)", false},
 
 	// Web Probing
 	{"httpx", "Probe", "HTTP probing & tech detection", true},
@@ -44,7 +44,6 @@ var allTools = []struct {
 	// Analysis
 	{"linkfinder", "Analysis", "JavaScript endpoint extraction (Python)", false},
 	{"subdomainizer", "Analysis", "JavaScript subdomain extraction (Python)", false},
-	{"cewl", "Analysis", "Custom wordlist generation", false},
 
 	// Fuzzing & Scanning
 	{"ffuf", "Fuzz", "Web fuzzer & directory brute-force", false},
@@ -57,6 +56,9 @@ var allTools = []struct {
 	{"metabigor", "Recon", "ASN & org discovery", false},
 	{"github-subdomains", "Recon", "GitHub subdomain scraping", false},
 	{"cloud_enum", "Cloud", "Cloud infrastructure enumeration (Python)", false},
+
+	// Utility
+	{"anew", "Util", "Append unique lines to file", false},
 }
 
 var toolsCmd = &cobra.Command{
@@ -83,39 +85,128 @@ func init() {
 	rootCmd.AddCommand(toolsCmd)
 }
 
-func runToolsList(cmd *cobra.Command, args []string) {
-	logger.Section("Chaathan Tool Suite")
-	fmt.Println()
+// ── Category metadata ────────────────────────────────────────────────────────
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "TOOL\tCATEGORY\tREQUIRED\tDESCRIPTION")
-	fmt.Fprintln(w, "────\t────────\t────────\t───────────")
-
-	for _, t := range allTools {
-		req := ""
-		if t.Required {
-			req = "✓"
-		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.Name, t.Category, req, t.Description)
-	}
-	w.Flush()
-
-	fmt.Println()
-	logger.Info("Total: %d tools (%d required)", len(allTools), countRequired())
-	logger.Info("Run 'chaathan tools check' to see installation status")
+type categoryMeta struct {
+	icon  string
+	color string
 }
 
-func runToolsCheck(cmd *cobra.Command, args []string) {
-	logger.Section("Tool Installation Check")
-	fmt.Println()
+var categoryStyles = map[string]categoryMeta{
+	"Enum":     {"🔎", logger.BrightCyan},
+	"DNS":      {"🌐", logger.BrightBlue},
+	"Probe":    {"📡", logger.BrightGreen},
+	"URLs":     {"🔗", logger.BrightPurple},
+	"Crawl":    {"🕷️", logger.Purple},
+	"Analysis": {"🧬", logger.Cyan},
+	"Fuzz":     {"💥", logger.BrightYellow},
+	"Vuln":     {"🛡️", logger.BrightRed},
+	"Recon":    {"🔭", logger.Blue},
+	"Cloud":    {"☁️", logger.BrightCyan},
+	"Util":     {"🔧", logger.Gray},
+}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "TOOL\tSTATUS\tPATH")
-	fmt.Fprintln(w, "────\t──────\t────")
+// ── Tools List ───────────────────────────────────────────────────────────────
+
+func runToolsList(_ *cobra.Command, _ []string) {
+	w := 52
+	line := strings.Repeat("─", w)
+
+	// Header box
+	fmt.Printf("\n  %s╭%s╮%s\n", logger.Cyan+logger.Bold, line, logger.Reset)
+	fmt.Printf("  %s│%s  🧰 %s%-46s%s %s│%s\n",
+		logger.Cyan+logger.Bold, logger.Reset,
+		logger.White+logger.Bold, "Chaathan Tool Suite", logger.Reset,
+		logger.Cyan+logger.Bold, logger.Reset)
+	fmt.Printf("  %s│%s  %s%-50s%s %s│%s\n",
+		logger.Cyan+logger.Bold, logger.Reset,
+		logger.Dim, fmt.Sprintf("%d tools • %d required", len(allTools), countRequired()), logger.Reset,
+		logger.Cyan+logger.Bold, logger.Reset)
+	fmt.Printf("  %s╰%s╯%s\n\n", logger.Cyan+logger.Bold, line, logger.Reset)
+
+	// Group tools by category (preserve order)
+	type catGroup struct {
+		name  string
+		tools []struct {
+			Name        string
+			Category    string
+			Description string
+			Required    bool
+		}
+	}
+	var groups []catGroup
+	seen := map[string]int{}
+
+	for _, t := range allTools {
+		if idx, ok := seen[t.Category]; ok {
+			groups[idx].tools = append(groups[idx].tools, t)
+		} else {
+			seen[t.Category] = len(groups)
+			groups = append(groups, catGroup{
+				name: t.Category,
+				tools: []struct {
+					Name, Category, Description string
+					Required                    bool
+				}{t},
+			})
+		}
+	}
+
+	for _, g := range groups {
+		meta := categoryStyles[g.name]
+		fmt.Printf("  %s┌─%s %s %s%s%s%s\n",
+			logger.Cyan, logger.Reset,
+			meta.icon, meta.color+logger.Bold, g.name, logger.Reset, "")
+
+		for _, t := range g.tools {
+			req := ""
+			if t.Required {
+				req = fmt.Sprintf(" %s[required]%s", logger.BrightYellow, logger.Reset)
+			}
+			fmt.Printf("  %s│%s  %-22s %s%s%s%s\n",
+				logger.Dim, logger.Reset,
+				t.Name,
+				logger.Dim, t.Description, logger.Reset, req)
+		}
+		fmt.Println()
+	}
+
+	// Footer
+	fmt.Printf("  %s%s%s\n", logger.Dim, strings.Repeat("━", 50), logger.Reset)
+	fmt.Printf("  %s💡 Run 'chaathan tools check' to see installation status%s\n\n", logger.Dim, logger.Reset)
+}
+
+// ── Tools Check ──────────────────────────────────────────────────────────────
+
+func runToolsCheck(_ *cobra.Command, _ []string) {
+	w := 52
+	line := strings.Repeat("─", w)
+
+	// Header box
+	fmt.Printf("\n  %s╭%s╮%s\n", logger.Cyan+logger.Bold, line, logger.Reset)
+	fmt.Printf("  %s│%s  🔍 %s%-46s%s %s│%s\n",
+		logger.Cyan+logger.Bold, logger.Reset,
+		logger.White+logger.Bold, "Tool Installation Check", logger.Reset,
+		logger.Cyan+logger.Bold, logger.Reset)
+	fmt.Printf("  %s╰%s╯%s\n", logger.Cyan+logger.Bold, line, logger.Reset)
 
 	installed := 0
 	missing := 0
 	missingRequired := 0
+
+	// Group tools by category for display (preserve order)
+	type toolResult struct {
+		name     string
+		required bool
+		found    bool
+		path     string
+	}
+	type catGroup struct {
+		name    string
+		results []toolResult
+	}
+	var groups []catGroup
+	seen := map[string]int{}
 
 	for _, t := range allTools {
 		path, err := exec.LookPath(t.Name)
@@ -126,30 +217,120 @@ func runToolsCheck(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		if err != nil {
-			status := "❌ missing"
+		result := toolResult{
+			name:     t.Name,
+			required: t.Required,
+			found:    err == nil,
+			path:     path,
+		}
+
+		if err == nil {
+			installed++
+		} else {
+			missing++
 			if t.Required {
-				status = "🔴 MISSING (required)"
 				missingRequired++
 			}
-			fmt.Fprintf(w, "%s\t%s\t-\n", t.Name, status)
-			missing++
+		}
+
+		if idx, ok := seen[t.Category]; ok {
+			groups[idx].results = append(groups[idx].results, result)
 		} else {
-			fmt.Fprintf(w, "%s\t✅ installed\t%s\n", t.Name, path)
-			installed++
+			seen[t.Category] = len(groups)
+			groups = append(groups, catGroup{
+				name:    t.Category,
+				results: []toolResult{result},
+			})
 		}
 	}
-	w.Flush()
 
+	// Render each category
+	for _, g := range groups {
+		meta := categoryStyles[g.name]
+		fmt.Printf("\n  %s┌─%s %s %s%s%s%s\n",
+			logger.Cyan, logger.Reset,
+			meta.icon, meta.color+logger.Bold, g.name, logger.Reset, "")
+
+		for _, r := range g.results {
+			if r.found {
+				// Shorten path for display
+				shortPath := r.path
+				if len(shortPath) > 35 {
+					shortPath = "…" + shortPath[len(shortPath)-34:]
+				}
+				fmt.Printf("  %s│%s  %s✓%s %-22s %s%s%s\n",
+					logger.Dim, logger.Reset,
+					logger.BrightGreen, logger.Reset,
+					r.name,
+					logger.Dim, shortPath, logger.Reset)
+			} else {
+				label := "missing"
+				color := logger.Yellow
+				icon := "○"
+				if r.required {
+					label = "MISSING (required)"
+					color = logger.BrightRed
+					icon = "✗"
+				}
+				fmt.Printf("  %s│%s  %s%s%s %-22s %s%s%s\n",
+					logger.Dim, logger.Reset,
+					color, icon, logger.Reset,
+					r.name,
+					color+logger.Dim, label, logger.Reset)
+			}
+		}
+	}
+
+	// ── Summary bar ──
 	fmt.Println()
-	logger.Info("Installed: %d/%d", installed, len(allTools))
+	fmt.Printf("  %s%s%s\n", logger.Dim, strings.Repeat("━", 50), logger.Reset)
 
+	// Progress indicator
+	total := len(allTools)
+	pct := float64(installed) / float64(total) * 100
+	barW := 20
+	filled := int(float64(installed) / float64(total) * float64(barW))
+	if filled > barW {
+		filled = barW
+	}
+
+	barColor := logger.BrightGreen
+	if pct < 50 {
+		barColor = logger.BrightRed
+	} else if pct < 80 {
+		barColor = logger.BrightYellow
+	}
+
+	bar := barColor + strings.Repeat("━", filled) + logger.Reset +
+		logger.Dim + strings.Repeat("╌", barW-filled) + logger.Reset
+
+	fmt.Printf("  %s %s%d%s/%d tools  %s%.0f%%%s\n",
+		bar,
+		logger.Bold, installed, logger.Reset, total,
+		barColor+logger.Bold, pct, logger.Reset)
+
+	var parts []string
+	if installed > 0 {
+		parts = append(parts, fmt.Sprintf("%s✓ %d installed%s", logger.BrightGreen, installed, logger.Reset))
+	}
+	if missing > 0 && missingRequired == 0 {
+		parts = append(parts, fmt.Sprintf("%s○ %d optional missing%s", logger.Yellow, missing, logger.Reset))
+	}
 	if missingRequired > 0 {
-		logger.Error("%d required tool(s) missing! Run: chaathan setup", missingRequired)
+		parts = append(parts, fmt.Sprintf("%s✗ %d required missing%s", logger.BrightRed, missingRequired, logger.Reset))
+	}
+	fmt.Printf("  %s\n", strings.Join(parts, "  "))
+	fmt.Printf("  %s%s%s\n", logger.Dim, strings.Repeat("━", 50), logger.Reset)
+
+	// Status message
+	if missingRequired > 0 {
+		fmt.Printf("\n  %s✗%s %s%d required tool(s) missing!%s\n", logger.BrightRed, logger.Reset, logger.Red, missingRequired, logger.Reset)
+		fmt.Printf("  %s💡 Run: %schaathan setup%s\n\n", logger.Dim, logger.Reset+logger.BrightCyan, logger.Reset)
 	} else if missing > 0 {
-		logger.Warning("%d optional tool(s) missing. Run 'chaathan setup' to install all.", missing)
+		fmt.Printf("\n  %s⚠%s %s%d optional tool(s) missing.%s\n", logger.BrightYellow, logger.Reset, logger.Yellow, missing, logger.Reset)
+		fmt.Printf("  %s💡 Run '%schaathan setup%s%s' to install all.%s\n\n", logger.Dim, logger.Reset+logger.BrightCyan, logger.Reset, logger.Dim, logger.Reset)
 	} else {
-		logger.Success("All tools installed!")
+		fmt.Printf("\n  %s✓%s %sAll tools installed! You're good to go.%s 🚀\n\n", logger.BrightGreen, logger.Reset, logger.BrightGreen, logger.Reset)
 	}
 }
 

--- a/cli/wildcard.go
+++ b/cli/wildcard.go
@@ -824,25 +824,10 @@ step2:
 	}
 
 	// =========================================================================
-	// Step 15: Wordlist Generation (CeWL)
-	// =========================================================================
-	logger.Section("Step 17: Wordlist Generation (CeWL)")
-	cewlOut := filepath.Join(resultDir, "cewl_wordlist.txt")
-	logger.SubStep("Running CeWL...")
-	if err := tb.RunCewl(ctx, "https://"+targetDomain, cewlOut); err != nil {
-		if Verbose {
-			logger.Warning("CeWL failed: %v", err)
-		}
-	} else {
-		logger.SubStep("[Done] CeWL wordlist generated")
-	}
-	stateMgr.MarkStepComplete(scanState, "wordlist_gen")
-
-	// =========================================================================
-	// Step 16: Directory Fuzzing (ffuf)
+	// Step 17: Directory Fuzzing (ffuf)
 	// =========================================================================
 	if wordlistPath != "" {
-		logger.Section("Step 18: Directory Fuzzing (ffuf)")
+		logger.Section("Step 17: Directory Fuzzing (ffuf)")
 		ffufOut := filepath.Join(resultDir, "ffuf_results.json")
 		targetURL := fmt.Sprintf("https://%s/FUZZ", targetDomain)
 		logger.SubStep("Running ffuf with wordlist: %s", wordlistPath)
@@ -852,11 +837,8 @@ step2:
 			logger.SubStep("[Done] ffuf - Results: %s", ffufOut)
 		}
 	} else {
-		logger.Section("Step 18: Skipping ffuf (no wordlist provided)")
+		logger.Section("Step 17: Skipping ffuf (no wordlist provided)")
 		logger.Info("Use --wordlist to enable directory fuzzing")
-		if _, err := os.Stat(cewlOut); err == nil {
-			logger.Info("Tip: You can use the generated CeWL wordlist: %s", cewlOut)
-		}
 	}
 	stateMgr.MarkStepComplete(scanState, "dir_fuzzing")
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -60,7 +60,6 @@ var WildcardSteps = []Step{
 	{Name: "js_subdomain_discovery", Description: "JavaScript Subdomain Extraction", Required: false, Tool: "subdomainizer"},
 	{Name: "param_discovery", Description: "HTTP Parameter Discovery", Required: false, Tool: "arjun"},
 	{Name: "url_consolidation", Description: "URL Consolidation & Live Check", Required: false, Tool: "httpx"},
-	{Name: "wordlist_gen", Description: "Wordlist Generation", Required: false, Tool: "cewl"},
 	{Name: "dir_fuzzing", Description: "Directory Fuzzing", Required: false, Tool: "ffuf"},
 	{Name: "vuln_scanning", Description: "Vulnerability Scanning (Infra)", Required: false, Tool: "nuclei"},
 	{Name: "vuln_scanning_urls", Description: "Vulnerability Scanning (URLs)", Required: false, Tool: "nuclei"},

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -436,57 +436,6 @@ func (t *ToolBox) RunNucleiURLs(ctx context.Context, urlsFile string, outputFile
 	return err
 }
 
-// --- Wordlist Generation ---
-
-// RunCewl generates custom wordlists from a target website
-func (t *ToolBox) RunCewl(ctx context.Context, url string, outputFile string, opts ...CewlOption) error {
-	cewlOpts := &cewlOptions{
-		minWordLen: 5,
-		depth:      2,
-		withCount:  false,
-	}
-	for _, opt := range opts {
-		opt(cewlOpts)
-	}
-
-	args := []string{
-		"-m", fmt.Sprintf("%d", cewlOpts.minWordLen),
-		"-d", fmt.Sprintf("%d", cewlOpts.depth),
-		"-w", outputFile,
-		url,
-	}
-	if cewlOpts.withCount {
-		args = append([]string{"-c"}, args...)
-	}
-	_, err := t.Runner.Run(ctx, "cewl", args)
-	return err
-}
-
-type cewlOptions struct {
-	minWordLen int
-	depth      int
-	withCount  bool
-}
-
-type CewlOption func(*cewlOptions)
-
-func CewlMinWordLen(n int) CewlOption {
-	return func(o *cewlOptions) {
-		o.minWordLen = n
-	}
-}
-
-func CewlDepth(n int) CewlOption {
-	return func(o *cewlOptions) {
-		o.depth = n
-	}
-}
-
-func CewlWithCount() CewlOption {
-	return func(o *cewlOptions) {
-		o.withCount = true
-	}
-}
 
 // --- GitHub Reconnaissance ---
 


### PR DESCRIPTION
Remove CeWL/ruby-based tooling and related code, simplify Go tool installation, and modernize the tools UI and setup flow. Changes include: update Makefile/README to use make all/build and run the built binary for setup; remove rubyTools and CeWL usage (deleted RunCewl and its options, removed wordlist_gen step from scans and wildcard flow); simplify goTools struct and installGoTool by removing CGO handling; add massdns to tool metadata and overhaul tools list/check commands with grouped, colored output and better status summaries. Also adjust step numbering and minor UX improvements for tool setup/check commands.