### PR TITLE
Add gf patterns, URL filtering & scan robustness

### DIFF
--- a/cli/setup.go
+++ b/cli/setup.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -129,6 +130,7 @@ var goTools = []struct {
 	{"metabigor", "github.com/j3ssie/metabigor@latest"},
 	{"shuffledns", "github.com/projectdiscovery/shuffledns/cmd/shuffledns@latest"},
 	{"anew", "github.com/tomnomnom/anew@latest"},
+	{"gf", "github.com/tomnomnom/gf@latest"},
 	{"dnsx", "github.com/projectdiscovery/dnsx/cmd/dnsx@latest"},
 	{"katana", "github.com/projectdiscovery/katana/cmd/katana@latest"},
 	{"ffuf", "github.com/ffuf/ffuf/v2@latest"},
@@ -145,11 +147,12 @@ var pyTools = []struct {
 	name     string
 	package_ string
 	cmdName  string
+	module   string
 }{
-	{"cloud_enum", "git+https://github.com/initstring/cloud_enum.git", "cloud_enum.py"},
-	{"sublist3r", "git+https://github.com/aboul3la/Sublist3r.git", "sublist3r.py"},
-	{"linkfinder", "git+https://github.com/GerbenJavado/LinkFinder.git", "linkfinder.py"},
-	{"arjun", "arjun", "arjun"},
+	{"cloud_enum", "git+https://github.com/initstring/cloud_enum.git", "cloud_enum.py", "cloud_enum"},
+	{"sublist3r", "git+https://github.com/aboul3la/Sublist3r.git", "sublist3r.py", "sublist3r"},
+	{"linkfinder", "git+https://github.com/GerbenJavado/LinkFinder.git", "linkfinder.py", "linkfinder"},
+	{"arjun", "arjun", "arjun", "arjun"},
 }
 
 // Python scripts that need manual installation (not available via pip)
@@ -160,7 +163,6 @@ var pyScripts = []struct {
 }{
 	{"subdomainizer", "https://github.com/nsonaniya2010/SubDomainizer.git", "SubDomainizer.py"},
 }
-
 
 // ── Main setup entrypoint ────────────────────────────────────────────────────
 
@@ -187,6 +189,12 @@ func runSetup(cmd *cobra.Command, args []string) {
 
 	// Go tools
 	i, s, f := installGoToolsSection()
+	totalInstalled += int32(i)
+	totalSkipped += int32(s)
+	totalFailed += int32(f)
+
+	// gf patterns
+	i, s, f = installGFPatternsSection()
 	totalInstalled += int32(i)
 	totalSkipped += int32(s)
 	totalFailed += int32(f)
@@ -352,6 +360,111 @@ func installGoTool(name, url string) error {
 	return captureCommandOutput(cmd, name)
 }
 
+func installGFPatternsSection() (installed, skipped, failed int) {
+	progress.Section("gf Patterns", "installing local pattern pack for step 19 URL filtering")
+
+	if _, err := exec.LookPath("gf"); err != nil {
+		progress.ItemInfo("gf binary not installed yet — skipping pattern install")
+		return 0, 1, 0
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		progress.ItemFail("gf patterns", "cannot determine home directory")
+		return 0, 0, 1
+	}
+
+	gfDir := filepath.Join(home, ".gf")
+	if err := os.MkdirAll(gfDir, 0755); err != nil {
+		progress.ItemFail("gf patterns", err.Error())
+		return 0, 0, 1
+	}
+
+	patterns := map[string]map[string][]string{
+		"ssrf": {
+			"flags": {"-iE"},
+			"patterns": {
+				`([?&](url|uri|path|dest|destination|redirect|redirect_uri|redir|return|return_url|next|data|site|domain|feed|host|port|to|out|view|continue|callback|reference)=)`,
+			},
+		},
+		"redirect": {
+			"flags": {"-iE"},
+			"patterns": {
+				`([?&](redirect|redirect_url|redirect_uri|redir|return|return_to|return_url|next|continue|dest|destination|callback)=)`,
+			},
+		},
+		"lfi": {
+			"flags": {"-iE"},
+			"patterns": {
+				`([?&](file|filename|filepath|path|page|include|template|doc|folder|root|pg)=)`,
+			},
+		},
+		"sqli": {
+			"flags": {"-iE"},
+			"patterns": {
+				`([?&](id|ids|user|user_id|uid|account|number|order|sort|group|search|query|filter|report|category|item|product)=)`,
+			},
+		},
+		"xss": {
+			"flags": {"-iE"},
+			"patterns": {
+				`([?&](q|query|search|s|lang|keyword|term|text|message|comment|redirect|url|next|return)=)`,
+			},
+		},
+		"rce": {
+			"flags": {"-iE"},
+			"patterns": {
+				`([?&](cmd|exec|command|execute|ping|query|code|do|daemon|process|upload|download)=)`,
+			},
+		},
+		"idor": {
+			"flags": {"-iE"},
+			"patterns": {
+				`(/(users|user|accounts|orders|order|projects|project|files|file|documents|document|invoices|invoice|tickets|ticket|profiles|profile|messages|message|payments|payment|api)/[^/?#]+)`,
+				`([?&](id|user_id|account_id|order_id|project_id|file_id|doc_id|invoice_id|ticket_id|profile_id|message_id|payment_id|uid)=)`,
+			},
+		},
+		"debug_logic": {
+			"flags": {"-iE"},
+			"patterns": {
+				`(/(debug|test|staging|dev|console|actuator|swagger|openapi|internal|admin|config|health|metrics))`,
+			},
+		},
+	}
+
+	installedCount := 0
+	skippedCount := 0
+	for name, pattern := range patterns {
+		path := filepath.Join(gfDir, name+".json")
+		if _, err := os.Stat(path); err == nil {
+			skippedCount++
+			continue
+		}
+
+		data, err := json.MarshalIndent(pattern, "", "  ")
+		if err != nil {
+			progress.ItemFail(name, "failed to marshal pattern")
+			failed++
+			continue
+		}
+		if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+			progress.ItemFail(name, err.Error())
+			failed++
+			continue
+		}
+		installedCount++
+	}
+
+	if installedCount > 0 {
+		progress.ItemOK(fmt.Sprintf("%d gf patterns installed", installedCount))
+	}
+	if installedCount == 0 && failed == 0 {
+		progress.ItemInfo("gf pattern pack already present")
+	}
+
+	return installedCount, skippedCount, failed
+}
+
 // ── Python Tools ─────────────────────────────────────────────────────────────
 
 func installPythonToolsSection() (installed, skipped, failed int) {
@@ -367,16 +480,17 @@ func installPythonToolsSection() (installed, skipped, failed int) {
 
 	// Filter
 	type pyTool struct {
-		name, pkg, cmd string
+		name, pkg, cmd, module string
 	}
 	var toInstall []pyTool
 	var skippedCount int
 	for _, t := range pyTools {
-		if _, err := exec.LookPath(t.cmdName); err == nil {
+		if pythonToolInstalled(t.name, t.cmdName, t.module) {
+			_ = ensurePythonToolShim(t.name, t.module)
 			skippedCount++
 			continue
 		}
-		toInstall = append(toInstall, pyTool{t.name, t.package_, t.cmdName})
+		toInstall = append(toInstall, pyTool{t.name, t.package_, t.cmdName, t.module})
 	}
 
 	// Also count scripts
@@ -420,6 +534,8 @@ func installPythonToolsSection() (installed, skipped, failed int) {
 
 			cmd := exec.Command(pip, "install", "--break-system-packages", tool.pkg)
 			if err := captureCommandOutput(cmd, tool.name); err != nil {
+				tracker.Fail(tool.name, err.Error())
+			} else if err := ensurePythonToolShim(tool.name, tool.module); err != nil {
 				tracker.Fail(tool.name, err.Error())
 			} else {
 				tracker.Complete(tool.name)
@@ -474,6 +590,54 @@ func installPythonToolsSection() (installed, skipped, failed int) {
 
 	i, _, f := tracker.Stats()
 	return i, skippedCount, f
+}
+
+func pythonToolInstalled(name, cmdName, module string) bool {
+	if _, err := exec.LookPath(name); err == nil {
+		return true
+	}
+	if cmdName != "" {
+		if _, err := exec.LookPath(cmdName); err == nil {
+			return true
+		}
+	}
+	if module != "" && pythonModuleInstalled(module) {
+		return true
+	}
+	return false
+}
+
+func pythonModuleInstalled(module string) bool {
+	if module == "" {
+		return false
+	}
+	cmd := exec.Command("python3", "-c", "import "+module)
+	return cmd.Run() == nil
+}
+
+func ensurePythonToolShim(name, module string) error {
+	if name == "" || module == "" {
+		return nil
+	}
+	if _, err := exec.LookPath(name); err == nil {
+		return nil
+	}
+	if !pythonModuleInstalled(module) {
+		return fmt.Errorf("%s module is not importable after install", module)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	binDir := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return err
+	}
+
+	shimPath := filepath.Join(binDir, name)
+	shim := fmt.Sprintf("#!/usr/bin/env bash\npython3 -m %s \"$@\"\n", module)
+	return os.WriteFile(shimPath, []byte(shim), 0755)
 }
 
 // ── MassDNS ──────────────────────────────────────────────────────────────────

--- a/cli/tools_cmd.go
+++ b/cli/tools_cmd.go
@@ -58,6 +58,7 @@ var allTools = []struct {
 
 	// Utility
 	{"anew", "Util", "Append unique lines to file", false},
+	{"gf", "Util", "Pattern-based URL/param filtering", false},
 }
 
 var toolsCmd = &cobra.Command{

--- a/cli/wildcard.go
+++ b/cli/wildcard.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -265,6 +266,7 @@ func runWildcard(cmd *cobra.Command, args []string) {
 	dnsxOut := filepath.Join(resultDir, "dnsx_resolved.json")
 	shufflednsOut := filepath.Join(resultDir, "shuffledns_bruteforce.txt")
 	httpxOut := filepath.Join(resultDir, "httpx_live.json")
+	httpxLiveHosts := filepath.Join(resultDir, "httpx_live_hosts.txt")
 	tlsxOut := filepath.Join(resultDir, "tlsx_certs.json")
 	naabuOut := filepath.Join(resultDir, "naabu_ports.txt")
 	katanaOut := filepath.Join(resultDir, "katana_urls.txt")
@@ -278,6 +280,9 @@ func runWildcard(cmd *cobra.Command, args []string) {
 	ffufOut := filepath.Join(resultDir, "ffuf_results.json")
 	nucleiOut := filepath.Join(resultDir, "nuclei_vulns.json")
 	nucleiURLOut := filepath.Join(resultDir, "nuclei_url_vulns.json")
+	nucleiURLTargets := filepath.Join(resultDir, "nuclei_url_targets.txt")
+	nucleiGFMatches := filepath.Join(resultDir, "nuclei_url_targets_gf.txt")
+	nucleiFallbackTargets := filepath.Join(resultDir, "nuclei_url_targets_fallback.txt")
 	subjackOut := filepath.Join(resultDir, "subjack_takeovers.txt")
 	paramURLsFile := filepath.Join(resultDir, "param_urls_live.txt")
 	dalfoxOut := filepath.Join(resultDir, "dalfox_xss.json")
@@ -441,6 +446,7 @@ step2:
 		logger.Section("Step 4: GitHub Subdomain Discovery")
 		logger.SubStep("Running github-subdomains...")
 		if err := tb.RunGithubSubdomains(ctx, targetDomain, githubToken, githubSubsOut); err != nil {
+			stateMgr.MarkStepFailed(scanState, "github_recon", err)
 			logger.Warning("GitHub subdomains failed: %v", err)
 		} else {
 			if scanID > 0 {
@@ -469,9 +475,8 @@ step2:
 		logger.Section("Step 5: Passive Search Engine Recon (Uncover)")
 		logger.SubStep("Running Uncover (Shodan/Censys/Fofa)...")
 		if err := tb.RunUncover(ctx, targetDomain, uncoverOut); err != nil {
-			if Verbose {
-				logger.Warning("Uncover failed: %v (check API keys in config)", err)
-			}
+			stateMgr.MarkStepFailed(scanState, "search_engine_recon", err)
+			logger.Warning("Uncover failed: %v (check API keys in config)", err)
 		} else {
 			if scanID > 0 {
 				subs, ports, _ := utils.ParseUncoverOutput(scanID, uncoverOut)
@@ -505,6 +510,7 @@ step2:
 			subdomainizerOut,
 		)
 		if err := utils.MergeAndDeduplicate(passiveSources, consolidatedSubs); err != nil {
+			stateMgr.MarkStepFailed(scanState, "consolidation", err)
 			logger.Error("Failed to consolidate: %v", err)
 		}
 		logger.Success("Consolidated list saved to %s", consolidatedSubs)
@@ -513,6 +519,7 @@ step2:
 		// DNS Resolution
 		logger.SubStep("Running DNSx for resolution...")
 		if err := tb.RunDnsx(ctx, consolidatedSubs, dnsxOut); err != nil {
+			stateMgr.MarkStepFailed(scanState, "dns_resolution", err)
 			logger.Error("DNSx failed: %v", err)
 		}
 		stateMgr.MarkStepComplete(scanState, "dns_resolution")
@@ -536,7 +543,8 @@ step2:
 		}); err != nil {
 			if err == ErrToolSkipped {
 				logger.Info("  ShuffleDNS skipped")
-			} else if Verbose {
+			} else {
+				stateMgr.MarkStepFailed(scanState, "dns_bruteforce", err)
 				logger.Warning("ShuffleDNS failed: %v", err)
 			}
 		} else {
@@ -574,6 +582,7 @@ step2:
 		logger.Section("Step 8: Live Web Server Probing")
 		logger.SubStep("Running Httpx...")
 		if err := tb.RunHttpx(ctx, consolidatedSubs, httpxOut); err != nil {
+			stateMgr.MarkStepFailed(scanState, "http_probing", err)
 			logger.Error("Httpx failed: %v", err)
 		} else {
 			if scanID > 0 {
@@ -598,9 +607,8 @@ step2:
 		logger.Section("Step 9: TLS Certificate Analysis (tlsx)")
 		logger.SubStep("Running tlsx — extracting SANs and checking cert issues...")
 		if err := tb.RunTlsx(ctx, consolidatedSubs, tlsxOut); err != nil {
-			if Verbose {
-				logger.Warning("tlsx failed: %v", err)
-			}
+			stateMgr.MarkStepFailed(scanState, "tls_analysis", err)
+			logger.Warning("tlsx failed: %v", err)
 		} else {
 			if scanID > 0 {
 				newSubs, certVulns, _ := utils.ParseTlsxOutput(scanID, tlsxOut, targetDomain)
@@ -632,6 +640,7 @@ step2:
 		logger.Section("Step 10: Port Scanning")
 		logger.SubStep("Running Naabu on all discovered subdomains...")
 		if err := tb.RunNaabuList(ctx, consolidatedSubs, naabuOut); err != nil {
+			stateMgr.MarkStepFailed(scanState, "port_scanning", err)
 			logger.Error("Naabu failed: %v", err)
 		} else {
 			if scanID > 0 {
@@ -657,12 +666,17 @@ step2:
 		logger.Section("Step 11: Web Crawling [RESUMED — skipping]")
 	} else if !skipCrawl {
 		logger.Section("Step 11: Web Crawling")
+		crawlFailed := false
+		var crawlFailMu sync.Mutex
 
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
 			logger.SubStep("[Start] Katana")
 			if err := tb.RunKatana(ctx, "https://"+targetDomain, katanaOut); err != nil {
+				crawlFailMu.Lock()
+				crawlFailed = true
+				crawlFailMu.Unlock()
 				logger.Warning("Katana failed: %v", err)
 			} else {
 				logger.SubStep("[Done] Katana")
@@ -677,6 +691,9 @@ step2:
 			defer wg.Done()
 			logger.SubStep("[Start] GoSpider")
 			if err := tb.RunGoSpider(ctx, "https://"+targetDomain, gospiderOut); err != nil {
+				crawlFailMu.Lock()
+				crawlFailed = true
+				crawlFailMu.Unlock()
 				logger.Warning("GoSpider failed: %v", err)
 			} else {
 				logger.SubStep("[Done] GoSpider")
@@ -688,6 +705,9 @@ step2:
 		}()
 
 		wg.Wait()
+		if crawlFailed {
+			stateMgr.MarkStepFailed(scanState, "web_crawling", fmt.Errorf("one or more crawlers failed"))
+		}
 		stateMgr.MarkStepComplete(scanState, "web_crawling")
 	} else {
 		logger.Section("Step 11: Skipping Web Crawling (--skip-crawl)")
@@ -708,9 +728,8 @@ step2:
 		logger.Section("Step 12: JavaScript Analysis")
 		logger.SubStep("Running Linkfinder...")
 		if err := tb.RunLinkfinder(ctx, "https://"+targetDomain, linkfinderOut); err != nil {
-			if Verbose {
-				logger.Warning("Linkfinder failed: %v", err)
-			}
+			stateMgr.MarkStepFailed(scanState, "js_analysis", err)
+			logger.Warning("Linkfinder failed: %v", err)
 		} else {
 			if scanID > 0 {
 				count, _ := utils.ParseEndpointsFile(scanID, linkfinderOut, "linkfinder")
@@ -733,7 +752,8 @@ step2:
 		}); err != nil {
 			if err == ErrToolSkipped {
 				logger.Info("  SubDomainizer skipped")
-			} else if Verbose {
+			} else {
+				stateMgr.MarkStepFailed(scanState, "js_subdomain_discovery", err)
 				logger.Warning("SubDomainizer failed: %v", err)
 			}
 		} else {
@@ -774,9 +794,8 @@ step2:
 			return tb.RunArjun(sCtx, "https://"+targetDomain, arjunOut)
 		}); err != nil {
 			if err != ErrToolSkipped {
-				if Verbose {
-					logger.Warning("Arjun failed: %v", err)
-				}
+				stateMgr.MarkStepFailed(scanState, "param_discovery", err)
+				logger.Warning("Arjun failed: %v", err)
 			}
 		} else {
 			logger.SubStep("[Done] Arjun parameter discovery")
@@ -802,6 +821,7 @@ step2:
 
 	logger.SubStep("Merging URLs from %d sources...", len(urlSources))
 	if err := utils.MergeAndDeduplicate(urlSources, allURLsRaw); err != nil {
+		stateMgr.MarkStepFailed(scanState, "url_consolidation", err)
 		logger.Warning("URL merge failed: %v", err)
 	} else {
 		rawCount, _ := utils.CountFileLines(allURLsRaw)
@@ -814,6 +834,7 @@ step2:
 		return tb.RunHttpxURLCheck(sCtx, allURLsRaw, allURLsLive)
 	}); err != nil {
 		if err != ErrToolSkipped {
+			stateMgr.MarkStepFailed(scanState, "url_consolidation", err)
 			logger.Warning("URL live-check failed: %v", err)
 		}
 		// Fallback: use raw URLs if live-check fails
@@ -854,7 +875,8 @@ step16:
 		}); err != nil {
 			if err == ErrToolSkipped {
 				logger.Info("  CeWL skipped")
-			} else if Verbose {
+			} else {
+				stateMgr.MarkStepFailed(scanState, "wordlist_generation", err)
 				logger.Warning("CeWL failed: %v", err)
 			}
 		} else if utils.FileExists(generatedWordlistOut) {
@@ -886,6 +908,7 @@ step17:
 		targetURL := fmt.Sprintf("https://%s/FUZZ", targetDomain)
 		logger.SubStep("Running ffuf with wordlist: %s", effectiveWordlist)
 		if err := tb.RunFfufWithFUZZ(ctx, targetURL, effectiveWordlist, ffufOut); err != nil {
+			stateMgr.MarkStepFailed(scanState, "dir_fuzzing", err)
 			logger.Warning("ffuf failed: %v", err)
 		} else {
 			logger.SubStep("[Done] ffuf - Results: %s", ffufOut)
@@ -910,35 +933,41 @@ step18:
 		logger.Section("Step 18: Vulnerability Scanning — Infra (Nuclei) [RESUMED — skipping]")
 	} else if !skipNuclei {
 		logger.Section("Step 18: Vulnerability Scanning — Infra (Nuclei)")
-		logger.SubStep("Running Nuclei on discovered subdomains...")
-		if err := runWithSkip(ctx, "nuclei (infra)", func(sCtx context.Context) error {
-			return tb.RunNuclei(sCtx, consolidatedSubs, nucleiOut)
-		}); err != nil {
-			if err == ErrToolSkipped {
-				logger.Info("  Nuclei infra scan skipped")
-			} else {
-				logger.Error("Nuclei failed: %v", err)
-			}
+		liveHostCount := collectLiveHostTargetsFromHttpx(httpxOut, httpxLiveHosts)
+		if liveHostCount == 0 {
+			logger.Info("  Skipping Nuclei infra scan (no live httpx hosts available)")
 		} else {
-			if scanID > 0 {
-				count, _ := utils.ParseNucleiOutput(scanID, nucleiOut)
-				logger.Info("  Found %d vulnerabilities", count)
+			logger.SubStep("Running Nuclei on %d live httpx hosts...", liveHostCount)
+			if err := runWithSkip(ctx, "nuclei (infra)", func(sCtx context.Context) error {
+				return tb.RunNuclei(sCtx, httpxLiveHosts, nucleiOut)
+			}); err != nil {
+				if err == ErrToolSkipped {
+					logger.Info("  Nuclei infra scan skipped")
+				} else {
+					stateMgr.MarkStepFailed(scanState, "vuln_scanning", err)
+					logger.Error("Nuclei failed: %v", err)
+				}
+			} else {
+				if scanID > 0 {
+					count, _ := utils.ParseNucleiOutput(scanID, nucleiOut)
+					logger.Info("  Found %d vulnerabilities", count)
 
-				// Send notifications for critical/high findings
-				if notifier != nil && count > 0 {
-					vulns, _ := database.GetVulnerabilities(scanID)
-					for _, v := range vulns {
-						if v.Severity == "critical" || v.Severity == "high" {
-							notifier.SendFinding(notify.Finding{
-								Target:      targetDomain,
-								Type:        "vulnerability",
-								Name:        v.Name,
-								Severity:    v.Severity,
-								Description: v.Description,
-								URL:         v.URL,
-								TemplateID:  v.TemplateID,
-								Timestamp:   time.Now(),
-							})
+					// Send notifications for critical/high findings
+					if notifier != nil && count > 0 {
+						vulns, _ := database.GetVulnerabilities(scanID)
+						for _, v := range vulns {
+							if v.Severity == "critical" || v.Severity == "high" {
+								notifier.SendFinding(notify.Finding{
+									Target:      targetDomain,
+									Type:        "vulnerability",
+									Name:        v.Name,
+									Severity:    v.Severity,
+									Description: v.Description,
+									URL:         v.URL,
+									TemplateID:  v.TemplateID,
+									Timestamp:   time.Now(),
+								})
+							}
 						}
 					}
 				}
@@ -961,19 +990,45 @@ step18:
 		logger.Section("Step 19: Vulnerability Scanning — URLs (Nuclei) [RESUMED — skipping]")
 	} else if !skipNuclei && utils.FileExists(allURLsLive) {
 		logger.Section("Step 19: Vulnerability Scanning — URLs (Nuclei)")
-		logger.SubStep("Running Nuclei on live URLs (stricter rate, medium+ severity)...")
-		if err := runWithSkip(ctx, "nuclei (URLs)", func(sCtx context.Context) error {
-			return tb.RunNucleiURLs(sCtx, allURLsLive, nucleiURLOut)
-		}); err != nil {
-			if err == ErrToolSkipped {
-				logger.Info("  Nuclei URL scan skipped")
-			} else if Verbose {
-				logger.Warning("Nuclei URL scan failed: %v", err)
+		gfCount := 0
+		if isGFUsable() {
+			logger.SubStep("Filtering live URLs with gf patterns before nuclei...")
+			gfCount = collectGFTargetURLs(ctx, tb, allURLsLive, nucleiGFMatches)
+			if gfCount > 0 {
+				logger.Info("  gf matched %d URLs across vulnerability patterns", gfCount)
+			} else {
+				logger.Info("  gf found no matches or no usable patterns; keeping fallback filter active")
 			}
 		} else {
-			if scanID > 0 {
-				count, _ := utils.ParseNucleiOutput(scanID, nucleiURLOut)
-				logger.Info("  Found %d URL-specific vulnerabilities", count)
+			logger.Info("  gf not available or pattern pack missing; using fallback URL filter")
+		}
+
+		fallbackCount := collectHighValueURLsFromFile(allURLsLive, nucleiFallbackTargets)
+		urlTargetCount := 0
+		if err := utils.MergeAndDeduplicate(existingFiles(nucleiGFMatches, nucleiFallbackTargets), nucleiURLTargets); err == nil {
+			urlTargetCount, _ = utils.CountFileLines(nucleiURLTargets)
+		}
+		if urlTargetCount == 0 {
+			logger.Info("  Skipping Nuclei URL scan (no parameterized or high-value URLs available)")
+		} else {
+			logger.SubStep("Running Nuclei on %d filtered URLs (gf + fallback high-value paths)...", urlTargetCount)
+			if fallbackCount > 0 {
+				logger.Info("  Fallback filter contributed %d parameterized/high-value URLs", fallbackCount)
+			}
+			if err := runWithSkip(ctx, "nuclei (URLs)", func(sCtx context.Context) error {
+				return tb.RunNucleiURLs(sCtx, nucleiURLTargets, nucleiURLOut)
+			}); err != nil {
+				if err == ErrToolSkipped {
+					logger.Info("  Nuclei URL scan skipped")
+				} else {
+					stateMgr.MarkStepFailed(scanState, "vuln_scanning_urls", err)
+					logger.Warning("Nuclei URL scan failed: %v", err)
+				}
+			} else {
+				if scanID > 0 {
+					count, _ := utils.ParseNucleiOutput(scanID, nucleiURLOut)
+					logger.Info("  Found %d URL-specific vulnerabilities", count)
+				}
 			}
 		}
 	} else if skipNuclei {
@@ -997,9 +1052,8 @@ step18:
 		logger.Section("Step 20: Subdomain Takeover Detection (Subjack)")
 		logger.SubStep("Running Subjack — checking for dangling CNAMEs...")
 		if err := tb.RunSubjack(ctx, consolidatedSubs, subjackOut); err != nil {
-			if Verbose {
-				logger.Warning("Subjack failed: %v", err)
-			}
+			stateMgr.MarkStepFailed(scanState, "takeover_detection", err)
+			logger.Warning("Subjack failed: %v", err)
 		} else {
 			if scanID > 0 {
 				count, _ := utils.ParseSubjackOutput(scanID, subjackOut)
@@ -1051,7 +1105,8 @@ step18:
 			}); err != nil {
 				if err == ErrToolSkipped {
 					logger.Info("  Dalfox skipped")
-				} else if Verbose {
+				} else {
+					stateMgr.MarkStepFailed(scanState, "xss_scanning", err)
 					logger.Warning("Dalfox failed: %v", err)
 				}
 			} else {
@@ -1109,6 +1164,174 @@ func collectParamURLsFromFile(inputFile, outputFile string) int {
 		}
 	}
 	return count
+}
+
+func collectLiveHostTargetsFromHttpx(inputFile, outputFile string) int {
+	file, err := os.Open(inputFile)
+	if err != nil {
+		return 0
+	}
+	defer file.Close()
+
+	f, err := os.Create(outputFile)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+
+	type httpxTarget struct {
+		URL string `json:"url"`
+	}
+
+	seen := make(map[string]bool)
+	count := 0
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var result httpxTarget
+		if err := json.Unmarshal([]byte(line), &result); err != nil {
+			continue
+		}
+		if result.URL == "" || seen[result.URL] {
+			continue
+		}
+
+		seen[result.URL] = true
+		fmt.Fprintln(f, result.URL)
+		count++
+	}
+
+	return count
+}
+
+func collectHighValueURLsFromFile(inputFile, outputFile string) int {
+	file, err := os.Open(inputFile)
+	if err != nil {
+		return 0
+	}
+	defer file.Close()
+
+	f, err := os.Create(outputFile)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+
+	seen := make(map[string]bool)
+	count := 0
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || seen[line] {
+			continue
+		}
+		if !isHighValueURL(line) {
+			continue
+		}
+
+		seen[line] = true
+		fmt.Fprintln(f, line)
+		count++
+	}
+
+	return count
+}
+
+func collectGFTargetURLs(ctx context.Context, tb *tools.ToolBox, inputFile, outputFile string) int {
+	patterns := []string{"ssrf", "redirect", "lfi", "sqli", "xss", "rce", "idor", "debug_logic"}
+	tmpFiles := make([]string, 0, len(patterns))
+
+	for _, pattern := range patterns {
+		tmpFile := outputFile + "." + pattern
+		if err := tb.RunGFPattern(ctx, pattern, inputFile, tmpFile); err != nil {
+			continue
+		}
+		if utils.FileExists(tmpFile) {
+			tmpFiles = append(tmpFiles, tmpFile)
+		}
+	}
+
+	if len(tmpFiles) == 0 {
+		return 0
+	}
+
+	if err := utils.MergeAndDeduplicate(tmpFiles, outputFile); err != nil {
+		return 0
+	}
+	count, _ := utils.CountFileLines(outputFile)
+	return count
+}
+
+func isGFUsable() bool {
+	if _, err := exec.LookPath("gf"); err != nil {
+		return false
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	gfDir := filepath.Join(home, ".gf")
+	if _, err := os.Stat(gfDir); err != nil {
+		return false
+	}
+
+	entries, err := os.ReadDir(gfDir)
+	if err != nil {
+		return false
+	}
+
+	return len(entries) > 0
+}
+
+func isHighValueURL(raw string) bool {
+	lower := strings.ToLower(raw)
+	if strings.Contains(lower, "?") && strings.Contains(lower, "=") {
+		return true
+	}
+
+	highValueMarkers := []string{
+		"/admin",
+		"/login",
+		"/signin",
+		"/signup",
+		"/auth",
+		"/oauth",
+		"/token",
+		"/graphql",
+		"/api",
+		"/v1/",
+		"/v2/",
+		"/rest/",
+		"/debug",
+		"/console",
+		"/actuator",
+		"/swagger",
+		"/openapi",
+		"/health",
+		"/metrics",
+		"/config",
+		"/upload",
+		"/callback",
+		"/redirect",
+		"/reset",
+		"/password",
+	}
+
+	for _, marker := range highValueMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // copyFile copies a file from src to dst

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -130,6 +130,17 @@ func (m *Manager) UpdateState(state *State) error {
 
 // MarkStepComplete marks a step as completed
 func (m *Manager) MarkStepComplete(state *State, stepName string) error {
+	// Clear prior failure records if this step later succeeds or is explicitly skipped.
+	if len(state.FailedSteps) > 0 {
+		filtered := state.FailedSteps[:0]
+		for _, fs := range state.FailedSteps {
+			if fs.Name != stepName {
+				filtered = append(filtered, fs)
+			}
+		}
+		state.FailedSteps = filtered
+	}
+
 	// Avoid double-counting steps (common when resume/skip paths re-mark).
 	for _, s := range state.CompletedSteps {
 		if s == stepName {

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -1,9 +1,11 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 
@@ -127,6 +129,14 @@ func (t *ToolBox) nucleiSeverity() []string {
 		return t.Config.Nuclei.Severity
 	}
 	return nil // default: all severities
+}
+
+func (t *ToolBox) nucleiInfraTags() []string {
+	return []string{"cves", "exposures", "misconfiguration", "takeovers", "ssl"}
+}
+
+func (t *ToolBox) nucleiURLTags() []string {
+	return []string{"xss", "sqli", "ssrf", "lfi", "rce", "redirect", "exposures"}
 }
 
 func (t *ToolBox) ffufThreads() int {
@@ -334,6 +344,7 @@ func (t *ToolBox) RunNuclei(ctx context.Context, targetsFile string, outputFile 
 		"-l", targetsFile,
 		"-c", strconv.Itoa(t.nucleiConcurrency()),
 		"-rl", strconv.Itoa(t.nucleiRateLimit()),
+		"-tags", strings.Join(t.nucleiInfraTags(), ","),
 		"-jsonl",
 		"-o", outputFile,
 	}
@@ -457,6 +468,7 @@ func (t *ToolBox) RunNucleiURLs(ctx context.Context, urlsFile string, outputFile
 		"-l", urlsFile,
 		"-c", strconv.Itoa(concurrency),
 		"-rl", strconv.Itoa(rateLimit),
+		"-tags", strings.Join(t.nucleiURLTags(), ","),
 		"-severity", "critical,high,medium",
 		"-jsonl",
 		"-o", outputFile,
@@ -470,6 +482,32 @@ func (t *ToolBox) RunNucleiURLs(ctx context.Context, urlsFile string, outputFile
 
 	_, err := t.Runner.Run(ctx, "nuclei", args)
 	return err
+}
+
+// RunGFPattern filters an input file with a single gf pattern and writes matches.
+func (t *ToolBox) RunGFPattern(ctx context.Context, pattern string, inputFile string, outputFile string) error {
+	if pattern == "" {
+		return fmt.Errorf("gf requires a pattern name")
+	}
+	if inputFile == "" {
+		return fmt.Errorf("gf requires an input file")
+	}
+
+	// gf is a local text-filtering utility that depends on the host's ~/.gf pattern pack.
+	// Run it natively so it works even when the main scan runner is in docker mode.
+	cmd := exec.CommandContext(ctx, "gf", pattern, inputFile)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("%v: %s", err, stderr.String())
+		}
+		return err
+	}
+	return writeToFile(outputFile, stdout.String())
 }
 
 // --- GitHub Reconnaissance ---


### PR DESCRIPTION
Add support for gf pattern pack installation and usage, improve URL filtering for Nuclei, and make scan state tracking more robust. Key changes:

- cli/setup.go: add gf to install list and implement installGFPatternsSection to populate ~/.gf with JSON patterns.
- cli/tools_cmd.go: register gf in the tools list.
- cli/wildcard.go: integrate gf-based filtering before Nuclei URL scans, add helpers to collect live hosts and high-value/parameterized URLs, fallback filtering, and better error/state handling for many scan steps (marking failed steps and handling crawler failures).
- pkg/scan/scan.go: clear previous failure records for a step when it later succeeds (prevent double-counting failed steps).
- pkg/tools/tools.go: add nuclei tag helpers, pass -tags to RunNuclei/RunNucleiURLs, and implement RunGFPattern to run gf locally.
- cli/setup.go/python: enhance Python tool installation by tracking module names, detect installed modules, and write small shim scripts in ~/.local/bin to expose installed python modules as command-line tools.

Overall this reduces noisy Nuclei runs by pre-filtering targets, makes tool installation more reliable (python shims and gf patterns), and improves scan resilience and state accounting.