### PR TITLE
Enhance Telegram alert, live-URL parsing & flow

### DIFF
--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -391,67 +391,106 @@ func (n *Notifier) sendSlackStepComplete(step StepComplete) error {
 
 // Telegram notification
 func (n *Notifier) sendTelegram(finding Finding) error {
-	emoji := getSeverityEmoji(finding.Severity)
+	header := getSeverityEmoji(finding.Severity)
+	sev := strings.ToUpper(finding.Severity)
 
-	text := fmt.Sprintf(`%s *[%s] %s*
-
-*Target:* %s
-*Type:* %s`,
-		emoji,
-		strings.ToUpper(finding.Severity),
-		escapeMarkdown(finding.Name),
+	text := fmt.Sprintf(
+		"%s *%s Finding*\n\n"+
+			"━━━━━━━━━━━━━━━━━━━━\n"+
+			"⚡ *\\[%s\\] %s*\n"+
+			"━━━━━━━━━━━━━━━━━━━━\n"+
+			"🎯 *Target*    %s\n"+
+			"🔖 *Type*    %s",
+		header, escapeMarkdown(sev),
+		sev, escapeMarkdown(finding.Name),
 		escapeMarkdown(finding.Target),
 		escapeMarkdown(finding.Type),
 	)
 
 	if finding.Description != "" {
-		text += fmt.Sprintf("\n*Description:* %s", escapeMarkdown(finding.Description))
+		text += fmt.Sprintf("\n📝 *Details*    %s", escapeMarkdown(finding.Description))
 	}
 
 	if finding.URL != "" {
-		text += fmt.Sprintf("\n*URL:* %s", finding.URL)
+		text += fmt.Sprintf("\n🔗 *URL*    %s", escapeMarkdown(finding.URL))
 	}
+
+	if finding.TemplateID != "" {
+		text += fmt.Sprintf("\n🗂 *Template*    %s", escapeMarkdown(finding.TemplateID))
+	}
+
+	text += "\n━━━━━━━━━━━━━━━━━━━━\n_Chaathan Scanner_"
 
 	return n.sendTelegramMessage(text)
 }
 
 func (n *Notifier) sendTelegramScanComplete(scan ScanComplete) error {
-	text := fmt.Sprintf(`✅ *Scan Completed*
-
-*Target:* %s
-*Scan ID:* %d
-*Duration:* %s`,
+	text := fmt.Sprintf(
+		"🏁 *Scan Completed*\n\n"+
+			"━━━━━━━━━━━━━━━━━━━━\n"+
+			"🎯 *Target*    %s\n"+
+			"🔢 *Scan ID*    %d\n"+
+			"━━━━━━━━━━━━━━━━━━━━\n"+
+			"📊 *Results*\n",
 		escapeMarkdown(scan.Target),
 		scan.ScanID,
-		scan.Duration.String(),
 	)
 
-	for k, v := range scan.Stats {
-		text += fmt.Sprintf("\n*%s:* %d", k, v)
+	// Display stats with per-metric emojis in a preferred order
+	orderedKeys := []string{"subdomains", "live", "urls", "endpoints", "ports", "vulnerabilities"}
+	printed := make(map[string]bool)
+	for _, k := range orderedKeys {
+		if v, ok := scan.Stats[k]; ok {
+			text += fmt.Sprintf("%s %s    %d\n", statEmoji(k), escapeMarkdown(strings.Title(k)), v)
+			printed[k] = true
+		}
 	}
+	// Any remaining keys not in the preferred order
+	for k, v := range scan.Stats {
+		if !printed[k] {
+			text += fmt.Sprintf("%s %s    %d\n", statEmoji(k), escapeMarkdown(strings.Title(k)), v)
+		}
+	}
+
+	text += fmt.Sprintf(
+		"━━━━━━━━━━━━━━━━━━━━\n"+
+			"⏱ *Duration*    %s\n"+
+			"_Chaathan Scanner_",
+		escapeMarkdown(formatDuration(scan.Duration)),
+	)
 
 	return n.sendTelegramMessage(text)
 }
 
 func (n *Notifier) sendTelegramStepComplete(step StepComplete) error {
-	text := fmt.Sprintf(`✅ *Step Completed*
+	findings := ""
+	if step.FindingsCount > 0 {
+		findings = fmt.Sprintf("*%d* 🚨", step.FindingsCount)
+	} else {
+		findings = "0"
+	}
 
-*Target:* %s
-*Step:* %d/%d
-*Name:* %s
-*Duration:* %s
-*Findings:* %d`,
+	text := fmt.Sprintf(
+		"✅ *Step Completed*\n\n"+
+			"━━━━━━━━━━━━━━━━━━━━\n"+
+			"🎯 *Target*    %s\n"+
+			"📊 *Progress*    %d / %d\n"+
+			"📋 *Step*    %s\n"+
+			"⏱ *Duration*    %s\n"+
+			"🔍 *Findings*    %s",
 		escapeMarkdown(step.Target),
 		step.StepNumber,
 		step.TotalSteps,
 		escapeMarkdown(formatStepLabel(step)),
-		step.Duration.String(),
-		step.FindingsCount,
+		escapeMarkdown(formatDuration(step.Duration)),
+		findings,
 	)
 
 	if step.ScanType != "" {
-		text += fmt.Sprintf("\n*Scan Type:* %s", escapeMarkdown(step.ScanType))
+		text += fmt.Sprintf("\n🏷 *Type*    %s", escapeMarkdown(step.ScanType))
 	}
+
+	text += "\n━━━━━━━━━━━━━━━━━━━━\n_Chaathan Scanner_"
 
 	return n.sendTelegramMessage(text)
 }
@@ -462,7 +501,7 @@ func (n *Notifier) sendTelegramMessage(text string) error {
 	payload := map[string]interface{}{
 		"chat_id":    n.cfg.TelegramChatID,
 		"text":       text,
-		"parse_mode": "Markdown",
+		"parse_mode": "MarkdownV2",
 	}
 
 	return n.postJSON(url, payload)
@@ -618,4 +657,47 @@ func escapeMarkdown(s string) string {
 		")", "\\)",
 	)
 	return replacer.Replace(s)
+}
+
+// formatDuration converts a duration to a clean human-readable string.
+// e.g. 19m56.166s → "19m 56s", 3723s → "1h 2m", 45s → "45s"
+func formatDuration(d time.Duration) string {
+	d = d.Round(time.Second)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		m := int(d.Minutes())
+		s := int(d.Seconds()) % 60
+		if s == 0 {
+			return fmt.Sprintf("%dm", m)
+		}
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	if m == 0 {
+		return fmt.Sprintf("%dh", h)
+	}
+	return fmt.Sprintf("%dh %dm", h, m)
+}
+
+// statEmoji returns an emoji for a known scan stat key.
+func statEmoji(key string) string {
+	switch strings.ToLower(key) {
+	case "subdomains":
+		return "🌐"
+	case "live":
+		return "💚"
+	case "urls":
+		return "🔗"
+	case "endpoints":
+		return "📌"
+	case "ports":
+		return "⚓"
+	case "vulnerabilities", "vulns":
+		return "🚨"
+	default:
+		return "📊"
+	}
 }

--- a/pkg/utils/parser.go
+++ b/pkg/utils/parser.go
@@ -291,6 +291,41 @@ func ParseURLsFile(scanID int64, filePath, source string) (int, error) {
 	return count, scanner.Err()
 }
 
+// ParseLiveURLsFile parses httpx plain-text output where each line may be
+// "https://url [STATUS_CODE]" (produced by -status-code without -json).
+// Only the primary URL field (before any whitespace) is stored in the DB,
+// so status suffixes never corrupt stored URLs.
+func ParseLiveURLsFile(scanID int64, filePath, source string) (int, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	seen := make(map[string]bool)
+	count := 0
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Take only the first field — strips "[200]", "[403]", etc.
+		fields := strings.Fields(line)
+		url := fields[0]
+		if url == "" || seen[url] {
+			continue
+		}
+		seen[url] = true
+		if err := database.AddURL(scanID, url, 0, "", "", "", source); err != nil {
+			continue
+		}
+		count++
+	}
+
+	return count, scanner.Err()
+}
+
 // ParseFfufOutput parses ffuf JSON output and stores discovered paths as both
 // URLs and endpoints so later ranking/reporting can use the fuzzing data.
 func ParseFfufOutput(scanID int64, filePath string) (int, error) {

--- a/pkg/wildcard_flow/asset_discovery.go
+++ b/pkg/wildcard_flow/asset_discovery.go
@@ -28,7 +28,7 @@ import (
 func stepPassiveEnum(c *Ctx) bool {
 	if c.State.IsStepCompleted("passive_enum") {
 		logger.StepHeader("Step 1: Passive Subdomain Enumeration [RESUMED — skipping]")
-		return false
+		return c.cancelled()
 	}
 	logger.StepHeader("Step 1: Passive Subdomain Enumeration")
 

--- a/pkg/wildcard_flow/content_discovery.go
+++ b/pkg/wildcard_flow/content_discovery.go
@@ -231,6 +231,7 @@ func stepJSAnalysis(c *Ctx) bool {
 func stepParamDiscovery(c *Ctx) bool {
 	if c.State.IsStepCompleted("param_discovery") {
 		logger.StepHeader("Step 14: HTTP Parameter Discovery (Arjun) [RESUMED — skipping]")
+		return c.cancelled()
 	} else if !c.SkipArjun {
 		logger.StepHeader("Step 14: HTTP Parameter Discovery (Arjun)")
 		logger.SubStep("Running Arjun on https://%s...", c.Domain)
@@ -238,9 +239,13 @@ func stepParamDiscovery(c *Ctx) bool {
 		if err := runWithSkip(c, "arjun", func(sCtx context.Context) error {
 			return c.Tb.RunArjun(sCtx, "https://"+c.Domain, c.F.ArjunOut)
 		}); err != nil {
-			if err != ErrToolSkipped {
+			if err == ErrToolSkipped {
+				// User-skipped counts as intentional — mark complete so resume skips it too.
+				c.StateMgr.MarkStepComplete(c.State, "param_discovery")
+			} else {
 				c.StateMgr.MarkStepFailed(c.State, "param_discovery", err)
 				logger.Warning("Arjun failed: %v", err)
+				// Do NOT fall through to MarkStepComplete — failure must persist for resume.
 			}
 		} else {
 			logger.SubStep("[Done] Arjun parameter discovery")
@@ -254,11 +259,12 @@ func stepParamDiscovery(c *Ctx) bool {
 					logger.Info("  Stored Arjun param counts for %d URLs", stored)
 				}
 			}
+			c.StateMgr.MarkStepComplete(c.State, "param_discovery")
 		}
 	} else {
 		logger.StepHeader("Step 14: Skipping Arjun (--skip-arjun)")
+		c.StateMgr.MarkStepComplete(c.State, "param_discovery")
 	}
-	c.StateMgr.MarkStepComplete(c.State, "param_discovery")
 	return c.cancelled()
 }
 
@@ -303,6 +309,16 @@ func stepURLConsolidation(c *Ctx) bool {
 	} else {
 		liveCount, _ := utils.CountFileLines(c.F.AllURLsLive)
 		logger.Success("  %d live URLs confirmed", liveCount)
+	}
+
+	// Persist live URLs into DB so GetScanStats / query commands reflect reality.
+	// This is intentionally after the skip/fallback block so both paths populate the DB.
+	if c.ScanID > 0 && utils.FileExists(c.F.AllURLsLive) {
+		if dbCount, err := utils.ParseLiveURLsFile(c.ScanID, c.F.AllURLsLive, "httpx-url-check"); err != nil {
+			logger.Warning("Failed to persist live URLs to DB: %v", err)
+		} else if dbCount > 0 {
+			logger.Info("  Stored %d live URLs in database", dbCount)
+		}
 	}
 
 	// ROI metadata enrichment

--- a/pkg/wildcard_flow/flow.go
+++ b/pkg/wildcard_flow/flow.go
@@ -250,7 +250,8 @@ func Run(cfg RunConfig) error {
 			if buf[0] == 's' || buf[0] == 'S' {
 				select {
 				case skipChan <- struct{}{}:
-					logger.Warning("⏭ Skip requested — skipping current tool...")
+					// "Skip requested" is logged by runWithSkip when it receives
+					// the signal, ensuring correct message ordering.
 				default:
 					// already a skip pending; ignore
 				}

--- a/pkg/wildcard_flow/helpers.go
+++ b/pkg/wildcard_flow/helpers.go
@@ -73,6 +73,7 @@ func runWithSkip(c *Ctx, toolName string, fn func(ctx context.Context) error) er
 		return err
 	case <-c.SkipChan:
 		toolCancel()
+		logger.Warning("⏭ Skip requested — skipping current tool...")
 		logger.Warning("⏭ Skipped: %s", toolName)
 		select {
 		case <-done:

--- a/pkg/wildcard_flow/validation.go
+++ b/pkg/wildcard_flow/validation.go
@@ -12,6 +12,8 @@ package wildcard_flow
 
 import (
 	"context"
+	neturl "net/url"
+	"strings"
 
 	"github.com/vishnu303/chaathan-flow/pkg/database"
 	"github.com/vishnu303/chaathan-flow/pkg/logger"
@@ -192,8 +194,14 @@ func stepTLSAnalysis(c *Ctx) bool {
 				logger.Info("  Stored metadata for %d live hosts", count)
 				// Ensure these hosts are marked live in the subdomains table,
 				// even if httpx was skipped and ParseHttpxOutput never ran.
+				// hostTargets contains full URLs (e.g. https://host); extract the
+				// plain hostname so the UPDATE matches the domain column correctly.
 				for _, h := range hostTargets {
-					database.UpdateSubdomainLive(c.ScanID, h, true, "")
+					host := h
+					if parsed, err := neturl.Parse(h); err == nil && parsed.Hostname() != "" {
+						host = strings.ToLower(parsed.Hostname())
+					}
+					database.UpdateSubdomainLive(c.ScanID, host, true, "")
 				}
 			}
 		}


### PR DESCRIPTION
Refactor Telegram notifications for richer formatting and MarkdownV2 support (new header, emojis, reordered stats). Add helper functions formatDuration and statEmoji to format durations and stat lines. Introduce ParseLiveURLsFile to parse httpx plain-text output and persist live URLs; persist live URLs after URL consolidation. Improve wildcard flow robustness: use c.cancelled() for resumed-step checks, log skip requests consistently in runWithSkip, and refine Arjun (param_discovery) handling so user-skips mark the step complete while actual failures are recorded. Also extract hostnames when marking subdomains live during TLS analysis to ensure DB updates match domain column.