### PR TITLE
Add scan logging

### DIFF
--- a/cli/wildcard.go
+++ b/cli/wildcard.go
@@ -39,6 +39,7 @@ var (
 	generateReport    bool
 	proxyURL          string
 	rateLimitRPS      int
+	saveLog           bool
 )
 
 // ─────────────────────────────────────────────────────────────
@@ -113,6 +114,7 @@ func init() {
 	wildcardCmd.Flags().BoolVar(&generateReport, "report", true, "Generate report after scan")
 	wildcardCmd.Flags().StringVar(&proxyURL, "proxy", "", "Proxy URL for target-facing tools (e.g., socks5://127.0.0.1:9050)")
 	wildcardCmd.Flags().IntVar(&rateLimitRPS, "rate-limit", 0, "Global rate limit (requests/sec) for all tools (0 = per-tool defaults)")
+	wildcardCmd.Flags().BoolVar(&saveLog, "log", false, "Save scan output to ~/.chaathan/logs/ (plain text, ANSI stripped)")
 	wildcardCmd.MarkFlagRequired("domain")
 	rootCmd.AddCommand(wildcardCmd)
 }
@@ -181,6 +183,7 @@ func runWildcard(cmd *cobra.Command, args []string) {
 		GitHubToken:       token,
 		ResumeScanID:      resumeScanID,
 		GenerateReport:    generateReport,
+		SaveLog:           saveLog,
 	}
 
 	if err := wf.Run(cfg); err != nil {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,12 +2,143 @@ package logger
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"regexp"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 )
 
-// ── ANSI codes ───────────────────────────────────────────────────────────────
+// ── File-log tee ─────────────────────────────────────────────────────────────
+
+var (
+	logFileMu sync.Mutex
+	logFile   *os.File
+)
+
+// ansiRE strips ANSI escape sequences so log files are readable plain text.
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// InitFileLog opens (or creates) the file at path and begins mirroring all
+// logger output to it with ANSI codes stripped. Call CloseFileLog() to flush
+// and close when the scan ends.
+func InitFileLog(path string) error {
+	logFileMu.Lock()
+	defer logFileMu.Unlock()
+	if logFile != nil {
+		logFile.Close()
+		logFile = nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("cannot open log file %q: %w", path, err)
+	}
+	logFile = f
+	return nil
+}
+
+// CloseFileLog flushes and closes the active log file.
+func CloseFileLog() {
+	logFileMu.Lock()
+	defer logFileMu.Unlock()
+	if logFile != nil {
+		logFile.Close()
+		logFile = nil
+	}
+}
+
+// logWrite writes to stdout and, if a log file is open, to the file with
+// ANSI codes stripped and a [HH:MM:SS] timestamp prefixed to each non-empty line.
+func logWrite(w io.Writer, s string) {
+	fmt.Fprint(w, s)
+	logFileMu.Lock()
+	defer logFileMu.Unlock()
+	if logFile != nil {
+		clean := ansiRE.ReplaceAllString(s, "")
+		ts := time.Now().Format("15:04:05")
+		lines := strings.Split(clean, "\n")
+		for i, line := range lines {
+			if line != "" {
+				lines[i] = "[" + ts + "] " + line
+			}
+		}
+		fmt.Fprint(logFile, strings.Join(lines, "\n"))
+	}
+}
+
+// WriteLogHeader writes a structured header to the open log file.
+// Call this immediately after InitFileLog. It writes directly to the file
+// (not through logWrite) so the header is not timestamped as a regular line.
+func WriteLogHeader(domain string, scanID int64, logFilePath string) {
+	logFileMu.Lock()
+	defer logFileMu.Unlock()
+	if logFile == nil {
+		return
+	}
+	now := time.Now().Format(time.RFC3339)
+	fmt.Fprintf(logFile, "=== Chaathan Wildcard Scan Log ===\n")
+	fmt.Fprintf(logFile, "Domain:   %s\n", domain)
+	if scanID > 0 {
+		fmt.Fprintf(logFile, "Scan ID:  %d\n", scanID)
+	}
+	fmt.Fprintf(logFile, "Started:  %s\n", now)
+	fmt.Fprintf(logFile, "Log file: %s\n", logFilePath)
+	fmt.Fprintf(logFile, "===================================\n\n")
+}
+
+// LogCommand writes the exact command invocation to the log file only.
+// Call this from the runner regardless of verbose mode so the log always
+// captures what was run. The terminal is not affected.
+func LogCommand(cmd string) {
+	logFileMu.Lock()
+	defer logFileMu.Unlock()
+	if logFile == nil {
+		return
+	}
+	ts := time.Now().Format("15:04:05")
+	fmt.Fprintf(logFile, "[%s]   $ %s\n", ts, cmd)
+}
+
+// LogToolFailure writes a structured tool failure block to the log file only.
+// Call this from the runner when a tool exits with an error. The terminal
+// still shows only the existing logger.Warning/Error messages.
+func LogToolFailure(tool, command, stderr string, exitErr error) {
+	logFileMu.Lock()
+	defer logFileMu.Unlock()
+	if logFile == nil {
+		return
+	}
+	ts := time.Now().Format("15:04:05")
+	fmt.Fprintf(logFile, "[%s] TOOL ERROR: %s\n", ts, tool)
+	fmt.Fprintf(logFile, "[%s]   Command: %s\n", ts, command)
+	if exitErr != nil {
+		fmt.Fprintf(logFile, "[%s]   Exit:    %v\n", ts, exitErr)
+	}
+	if stderr != "" {
+		fmt.Fprintf(logFile, "[%s]   Stderr:\n", ts)
+		for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
+			fmt.Fprintf(logFile, "[%s]     %s\n", ts, line)
+		}
+	}
+	fmt.Fprintf(logFile, "\n")
+}
+// FileDebug writes a debug-level line to the log file only.
+// It never prints to the terminal, making it safe to use for verbose internal
+// state (file sizes, skip decisions, pipeline counts) without adding noise.
+func FileDebug(format string, args ...interface{}) {
+	logFileMu.Lock()
+	defer logFileMu.Unlock()
+	if logFile == nil {
+		return
+	}
+	ts := time.Now().Format("15:04:05")
+	msg := fmt.Sprintf(format, args...)
+	fmt.Fprintf(logFile, "[%s] DEBUG %s\n", ts, msg)
+}
+
+
 
 var (
 	Reset     = "\033[0m"
@@ -62,31 +193,31 @@ func InitScanUI(total int) {
 // Info prints a styled info message
 func Info(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	fmt.Printf("  %s│%s %s\n", Dim, Reset, msg)
+	logWrite(os.Stdout, fmt.Sprintf("  %s│%s %s\n", Dim, Reset, msg))
 }
 
 // Success prints a styled success message
 func Success(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	fmt.Printf("  %s│%s %s✓%s %s\n", Dim, Reset, BrightGreen, Reset, msg)
+	logWrite(os.Stdout, fmt.Sprintf("  %s│%s %s✓%s %s\n", Dim, Reset, BrightGreen, Reset, msg))
 }
 
 // Warning prints a styled warning message
 func Warning(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	fmt.Printf("  %s│%s %s⚠%s %s\n", Dim, Reset, BrightYellow, Reset, msg)
+	logWrite(os.Stdout, fmt.Sprintf("  %s│%s %s⚠%s %s\n", Dim, Reset, BrightYellow, Reset, msg))
 }
 
 // Error prints a styled error message
 func Error(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	fmt.Printf("  %s│%s %s✗%s %s%s%s\n", Dim, Reset, BrightRed, Reset, Red, msg, Reset)
+	logWrite(os.Stdout, fmt.Sprintf("  %s│%s %s✗%s %s%s%s\n", Dim, Reset, BrightRed, Reset, Red, msg, Reset))
 }
 
 // Debug prints a styled debug message (only visible contextually)
 func Debug(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	fmt.Printf("  %s│  %s%s\n", Dim, msg, Reset)
+	logWrite(os.Stdout, fmt.Sprintf("  %s│  %s%s\n", Dim, msg, Reset))
 }
 
 // Section prints a generic section heading without incrementing the step counter.
@@ -94,7 +225,7 @@ func Debug(format string, args ...interface{}) {
 // that don't participate in the step-tracking workflow.
 func Section(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	fmt.Printf("\n  %s┌─%s %s%s%s%s\n", Cyan, Reset, BrightCyan+Bold, msg, Reset, "")
+	logWrite(os.Stdout, fmt.Sprintf("\n  %s┌─%s %s%s%s%s\n", Cyan, Reset, BrightCyan+Bold, msg, Reset, ""))
 }
 
 // StepHeader prints a scan-step heading that increments the step counter
@@ -113,7 +244,7 @@ func StepHeader(format string, args ...interface{}) {
 		stepIndicator = fmt.Sprintf("%s[%d/%d]%s ", Dim, currentStep, totalSteps, Reset)
 	}
 
-	fmt.Printf("\n  %s┌─%s %s%s%s%s%s%s\n", Cyan, Reset, stepIndicator, BrightCyan+Bold, msg, Reset, elapsed, "")
+	logWrite(os.Stdout, fmt.Sprintf("\n  %s┌─%s %s%s%s%s%s%s\n", Cyan, Reset, stepIndicator, BrightCyan+Bold, msg, Reset, elapsed, ""))
 }
 
 // ScanHeader prints the main scan workflow header
@@ -121,29 +252,29 @@ func ScanHeader(scanType string, target string, scanID int64) {
 	w := 52
 	line := strings.Repeat("─", w)
 
-	fmt.Printf("\n")
-	fmt.Printf("  %s╭%s╮%s\n", Cyan+Bold, line, Reset)
+	logWrite(os.Stdout, "\n")
+	logWrite(os.Stdout, fmt.Sprintf("  %s╭%s╮%s\n", Cyan+Bold, line, Reset))
 	// '  ' (2) + '🔍 ' (3) + 46 + ' ' (1) = 52
-	fmt.Printf("  %s│%s  🔍 %s%-46s%s %s│%s\n", Cyan+Bold, Reset, White+Bold, scanType+" Scan", Reset, Cyan+Bold, Reset)
+	logWrite(os.Stdout, fmt.Sprintf("  %s│%s  🔍 %s%-46s%s %s│%s\n", Cyan+Bold, Reset, White+Bold, scanType+" Scan", Reset, Cyan+Bold, Reset))
 	// '  ' (2) + '🎯 ' (3) + 'Target:' (7) + ' ' (1) + 38 + ' ' (1) = 52
-	fmt.Printf("  %s│%s  %s🎯 Target:%s %-38s %s│%s\n", Cyan+Bold, Reset, Dim, Reset, target, Cyan+Bold, Reset)
+	logWrite(os.Stdout, fmt.Sprintf("  %s│%s  %s🎯 Target:%s %-38s %s│%s\n", Cyan+Bold, Reset, Dim, Reset, target, Cyan+Bold, Reset))
 	if scanID > 0 {
 		// '  ' (2) + '🆔 ' (3) + 'Scan ID:' (8) + ' ' (1) + 37 + ' ' (1) = 52
-		fmt.Printf("  %s│%s  %s🆔 Scan ID:%s %-37d %s│%s\n", Cyan+Bold, Reset, Dim, Reset, scanID, Cyan+Bold, Reset)
+		logWrite(os.Stdout, fmt.Sprintf("  %s│%s  %s🆔 Scan ID:%s %-37d %s│%s\n", Cyan+Bold, Reset, Dim, Reset, scanID, Cyan+Bold, Reset))
 	}
-	fmt.Printf("  %s╰%s╯%s\n", Cyan+Bold, line, Reset)
-	fmt.Printf("\n")
+	logWrite(os.Stdout, fmt.Sprintf("  %s╰%s╯%s\n", Cyan+Bold, line, Reset))
+	logWrite(os.Stdout, "\n")
 }
 
 // SubStep prints an indented sub-step with arrow
 func SubStep(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	fmt.Printf("  %s│%s   %s▸%s %s\n", Dim, Reset, Purple, Reset, msg)
+	logWrite(os.Stdout, fmt.Sprintf("  %s│%s   %s▸%s %s\n", Dim, Reset, Purple, Reset, msg))
 }
 
 // Command prints the command being executed
 func Command(cmd string) {
-	fmt.Printf("  %s│     $ %s%s\n", Dim, cmd, Reset)
+	logWrite(os.Stdout, fmt.Sprintf("  %s│     $ %s%s\n", Dim, cmd, Reset))
 }
 
 // ── Summary helpers ─────────────────────────────────────────────────────────
@@ -164,44 +295,51 @@ func ScanSummary(status string, target string, scanID int64, duration time.Durat
 		statusColor = BrightRed
 	}
 
-	fmt.Printf("\n")
-	fmt.Printf("  %s╭%s╮%s\n", Cyan+Bold, line, Reset)
-	
+	logWrite(os.Stdout, "\n")
+	logWrite(os.Stdout, fmt.Sprintf("  %s╭%s╮%s\n", Cyan+Bold, line, Reset))
+
 	statusStr := capitalize(status)
 	pad1 := w - 2 - 1 - 6 - len(statusStr) // '  ' (2), statusIcon (1), ' Scan ' (6)
-	if pad1 < 0 { pad1 = 0 }
-	fmt.Printf("  %s│%s  %s%s%s %sScan %s%s%s%s│%s\n",
+	if pad1 < 0 {
+		pad1 = 0
+	}
+	logWrite(os.Stdout, fmt.Sprintf("  %s│%s  %s%s%s %sScan %s%s%s%s│%s\n",
 		Cyan+Bold, Reset, statusColor+Bold, statusIcon, Reset,
 		White+Bold, statusStr, Reset,
-		strings.Repeat(" ", pad1), Cyan+Bold, Reset)
+		strings.Repeat(" ", pad1), Cyan+Bold, Reset))
 
-	pad2 := w - 2 - 2 - len(target) - 1 // '  ' (2), '🎯' (1/2), len(target), extra space. Assume '🎯 ' is 3 columns.
-	pad2 = w - 5 - len(target)
-	if pad2 < 0 { pad2 = 0 }
-	fmt.Printf("  %s│%s  %s🎯 %s%s%s%s│%s\n", Cyan+Bold, Reset, Dim, target, Reset, strings.Repeat(" ", pad2), Cyan+Bold, Reset)
+	pad2 := w - 5 - len(target)
+	if pad2 < 0 {
+		pad2 = 0
+	}
+	logWrite(os.Stdout, fmt.Sprintf("  %s│%s  %s🎯 %s%s%s%s│%s\n", Cyan+Bold, Reset, Dim, target, Reset, strings.Repeat(" ", pad2), Cyan+Bold, Reset))
 
 	durStr := fmtDuration(duration)
 	pad3 := w - 6 - len(durStr) // '  ' (2) + '⏱  ' (4)
-	if pad3 < 0 { pad3 = 0 }
-	fmt.Printf("  %s│%s  %s⏱  %s%s%s%s│%s\n", Cyan+Bold, Reset, Dim, durStr, Reset, strings.Repeat(" ", pad3), Cyan+Bold, Reset)
+	if pad3 < 0 {
+		pad3 = 0
+	}
+	logWrite(os.Stdout, fmt.Sprintf("  %s│%s  %s⏱  %s%s%s%s│%s\n", Cyan+Bold, Reset, Dim, durStr, Reset, strings.Repeat(" ", pad3), Cyan+Bold, Reset))
 
 	if len(stats) > 0 {
-		fmt.Printf("  %s│%s  %s%s%s%s│%s\n", Cyan+Bold, Reset, Dim, strings.Repeat("╌", w-2), Reset, Cyan+Bold, Reset)
+		logWrite(os.Stdout, fmt.Sprintf("  %s│%s  %s%s%s%s│%s\n", Cyan+Bold, Reset, Dim, strings.Repeat("╌", w-2), Reset, Cyan+Bold, Reset))
 		for label, value := range stats {
 			// '  ' (2) + len(label) + 1 + len(value)
 			used := 2 + len(label) + 1 + len(value)
 			padding := w - used
-			if padding < 1 { padding = 1 }
-			fmt.Printf("  %s│%s  %s%s%s %s%s%s%s %s│%s\n",
+			if padding < 1 {
+				padding = 1
+			}
+			logWrite(os.Stdout, fmt.Sprintf("  %s│%s  %s%s%s %s%s%s%s %s│%s\n",
 				Cyan+Bold, Reset,
 				Dim, label+":", Reset,
 				BrightCyan+Bold, value, Reset,
 				strings.Repeat(" ", padding-1),
-				Cyan+Bold, Reset)
+				Cyan+Bold, Reset))
 		}
 	}
 
-	fmt.Printf("  %s╰%s╯%s\n", Cyan+Bold, line, Reset)
+	logWrite(os.Stdout, fmt.Sprintf("  %s╰%s╯%s\n", Cyan+Bold, line, Reset))
 }
 
 // NextSteps prints styled next step hints
@@ -209,11 +347,11 @@ func NextSteps(hints []string) {
 	if len(hints) == 0 {
 		return
 	}
-	fmt.Printf("\n  %s💡 Next steps:%s\n", Dim, Reset)
+	logWrite(os.Stdout, fmt.Sprintf("\n  %s💡 Next steps:%s\n", Dim, Reset))
 	for _, h := range hints {
-		fmt.Printf("     %s▸%s %s%s%s\n", Purple, Reset, Dim, h, Reset)
+		logWrite(os.Stdout, fmt.Sprintf("     %s▸%s %s%s%s\n", Purple, Reset, Dim, h, Reset))
 	}
-	fmt.Println()
+	logWrite(os.Stdout, "\n")
 }
 
 // ── Utility ─────────────────────────────────────────────────────────────────

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -70,3 +70,8 @@ func DatabasePath() string {
 func ConfigPath() string {
 	return filepath.Join(ChaathanHome(), "config.yaml")
 }
+
+// LogsDir returns the scan log directory (~/.chaathan/logs).
+func LogsDir() string {
+	return filepath.Join(ChaathanHome(), "logs")
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -131,8 +131,11 @@ func (r *NativeRunner) runOnce(ctx context.Context, command string, args []strin
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
+	cmdStr := fmt.Sprintf("%s %s", command, strings.Join(args, " "))
+	// Always write command to log file (file-only, no terminal noise)
+	logger.LogCommand(cmdStr)
 	if r.Verbose {
-		logger.Command(fmt.Sprintf("%s %s", command, strings.Join(args, " ")))
+		logger.Command(cmdStr)
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -141,6 +144,8 @@ func (r *NativeRunner) runOnce(ctx context.Context, command string, args []strin
 
 	err := startAndWait(ctx, cmd)
 	if err != nil {
+		// Write full stderr to log file for debugging
+		logger.LogToolFailure(command, cmdStr, stderr.String(), err)
 		if r.Verbose {
 			logger.Debug("CMD Error: %v | Stderr: %s", err, stderr.String())
 		}
@@ -207,8 +212,11 @@ func (r *DockerRunner) runOnce(ctx context.Context, command string, args []strin
 
 	dockerArgs = append(dockerArgs, args...)
 
+	cmdStr := fmt.Sprintf("DOCKER %s", strings.Join(dockerArgs, " "))
+	// Always write command to log file (file-only, no terminal noise)
+	logger.LogCommand(cmdStr)
 	if r.Verbose {
-		logger.Command(fmt.Sprintf("DOCKER %s", strings.Join(dockerArgs, " ")))
+		logger.Command(cmdStr)
 	}
 
 	cmd := exec.CommandContext(ctx, "docker", dockerArgs...)
@@ -219,6 +227,8 @@ func (r *DockerRunner) runOnce(ctx context.Context, command string, args []strin
 
 	err := startAndWait(ctx, cmd)
 	if err != nil {
+		// Write full stderr to log file for debugging
+		logger.LogToolFailure(command, cmdStr, stderr.String(), err)
 		if stderr.Len() > 0 {
 			return stdout.String(), fmt.Errorf("%v: %s", err, stderr.String())
 		}

--- a/pkg/setup/python_tools.go
+++ b/pkg/setup/python_tools.go
@@ -80,16 +80,25 @@ func installPythonToolsSection() (installed, skipped, failed int) {
 			defer wg.Done()
 			tracker.Start(tool.name)
 			args := []string{"install", "--break-system-packages", tool.pkg}
-			// Both sublist3r and arjun use unpinned older requests/urllib3 which breaks on Python 3.12+ 
-			// due to the complete removal of the six module from urllib3.packages. 
-			// We force an upgrade (or constraint) to a working urllib3 1.26.x series here.
-			if tool.name == "sublist3r" || tool.name == "arjun" {
-				args = append(args, "urllib3>=1.26.18,<2")
-			}
 			cmd := exec.Command(pip, args...)
 			if err := captureCommandOutput(cmd, tool.name); err != nil {
 				tracker.Fail(tool.name, err.Error())
-			} else if err := ensurePythonToolShim(tool.name, tool.module); err != nil {
+				return
+			}
+			// sublist3r and arjun depend on requests/urllib3, but urllib3 v2.x dropped
+			// urllib3.packages.six.moves, which both tools rely on. A constraint in the
+			// install command above is insufficient when urllib3 v2 is already globally
+			// installed — pip won't downgrade an already-satisfied dependency. Force a
+			// separate reinstall to guarantee the working 1.26.x series is on disk.
+			if tool.name == "sublist3r" || tool.name == "arjun" {
+				pinArgs := []string{"install", "--break-system-packages", "--force-reinstall", "urllib3>=1.26.18,<2"}
+				pinCmd := exec.Command(pip, pinArgs...)
+				if err := captureCommandOutput(pinCmd, tool.name+" (urllib3 pin)"); err != nil {
+					tracker.Fail(tool.name, "urllib3 pin failed: "+err.Error())
+					return
+				}
+			}
+			if err := ensurePythonToolShim(tool.name, tool.module); err != nil {
 				tracker.Fail(tool.name, err.Error())
 			} else {
 				tracker.Complete(tool.name)

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -260,11 +260,12 @@ func (t *ToolBox) nucleiSeverity() []string {
 }
 
 func (t *ToolBox) nucleiInfraTags() []string {
-	return []string{"cve", "exposure", "misconfig", "takeover", "ssl"}
+	return []string{"cve", "rce", "sqli", "ssrf", "lfi", "exposure", "default-login", "misconfig"}
 }
 
 func (t *ToolBox) nucleiURLTags() []string {
-	return []string{"xss", "sqli", "ssrf", "lfi", "rce", "redirect", "exposure"}
+	// xss is handled by Dalfox (Step 21) — no duplication needed here
+	return []string{"sqli", "ssrf", "lfi", "rce", "ssti", "idor"}
 }
 
 func (t *ToolBox) ffufThreads() int {
@@ -345,7 +346,13 @@ func (t *ToolBox) RunGau(ctx context.Context, domain string, outputFile string) 
 // --- DNS & Brute Force ---
 
 func (t *ToolBox) RunDnsx(ctx context.Context, inputFile string, outputFile string) error {
-	args := []string{"-l", inputFile, "-a", "-aaaa", "-cname", "-mx", "-txt", "-resp", "-json", "-o", outputFile}
+	args := []string{
+		"-l", inputFile,
+		"-a", "-aaaa", "-cname", "-mx", "-txt", "-resp", "-json",
+		"-timeout", "3", // seconds per DNS query
+		"-retry", "2",  // retry failed queries twice before giving up
+		"-o", outputFile,
+	}
 	_, err := t.Runner.Run(ctx, "dnsx", args)
 	return err
 }
@@ -379,6 +386,7 @@ func (t *ToolBox) RunNaabu(ctx context.Context, host string, outputFile string) 
 		"-host", host,
 		"-rate", strconv.Itoa(t.effectiveRate(t.naabuRate())),
 		"-c", strconv.Itoa(t.naabuThreads()),
+		"-timeout", "3", // seconds per probe; prevents hanging on filtered ports
 		"-o", outputFile,
 	}
 	// Use explicit port list if configured, otherwise use -top-ports
@@ -406,6 +414,7 @@ func (t *ToolBox) RunNaabuList(ctx context.Context, inputFile string, outputFile
 		"-l", inputFile,
 		"-rate", strconv.Itoa(t.effectiveRate(t.naabuRate())),
 		"-c", strconv.Itoa(t.naabuThreads()),
+		"-timeout", "3", // seconds per probe; prevents hanging on filtered ports
 		"-o", outputFile,
 	}
 	// Use explicit port list if configured, otherwise use -top-ports
@@ -430,7 +439,7 @@ func (t *ToolBox) RunNaabuList(ctx context.Context, inputFile string, outputFile
 // --- Web Crawling & Fuzzing ---
 
 func (t *ToolBox) RunGoSpider(ctx context.Context, inputFile string, outputFile string) error {
-	args := []string{"-S", inputFile, "-q", "-c", "10", "-d", "3"}
+	args := []string{"-S", inputFile, "-q", "-c", "10", "-d", "3", "-t", "10"} // -t = per-request timeout (seconds)
 	args = t.appendGoSpiderUA(args)
 	args = t.appendProxy(args, "--proxy")
 	output, err := t.Runner.Run(ctx, "gospider", args)
@@ -443,7 +452,12 @@ func (t *ToolBox) RunGoSpider(ctx context.Context, inputFile string, outputFile 
 }
 
 func (t *ToolBox) RunKatana(ctx context.Context, inputFile string, outputFile string) error {
-	args := []string{"-list", inputFile, "-o", outputFile, "-jc"}
+	args := []string{
+		"-list", inputFile,
+		"-o", outputFile,
+		"-jc",
+		"-timeout", "10", // seconds per request
+	}
 	args = t.appendUAHeader(args)
 	args = t.appendProxy(args, "-proxy")
 	if rps := t.globalRPS(); rps > 0 {
@@ -511,6 +525,8 @@ func (t *ToolBox) RunNuclei(ctx context.Context, targetsFile string, outputFile 
 		"-l", targetsFile,
 		"-c", strconv.Itoa(t.nucleiConcurrency()),
 		"-rl", strconv.Itoa(rateLimit),
+		"-timeout", "5",        // per-request timeout (seconds)
+		"-max-host-error", "5", // bail out of a host after 5 consecutive errors
 		"-tags", strings.Join(t.nucleiInfraTags(), ","),
 		"-jsonl",
 		"-o", outputFile,
@@ -522,10 +538,13 @@ func (t *ToolBox) RunNuclei(ctx context.Context, targetsFile string, outputFile 
 		args = append(args, "-etags", strings.Join(excludeTags, ","))
 	}
 
-	// Apply severity filter from config
+	// Apply severity filter: use config value if set, else default to critical,high
+	// (never inject both — nuclei uses the last -severity flag, silently discarding the first)
 	severity := t.nucleiSeverity()
 	if len(severity) > 0 {
 		args = append(args, "-severity", strings.Join(severity, ","))
+	} else {
+		args = append(args, "-severity", "critical,high") // skip info/low/medium on infra — too noisy
 	}
 
 	args = t.appendUAHeader(args)
@@ -689,6 +708,9 @@ func (t *ToolBox) RunNucleiURLs(ctx context.Context, urlsFile string, outputFile
 		"-l", urlsFile,
 		"-c", strconv.Itoa(concurrency),
 		"-rl", strconv.Itoa(rateLimit),
+		"-timeout", "5",          // per-request timeout (seconds)
+		"-max-host-error", "3",   // bail out of a host after 3 consecutive errors (blocked IPs don't stall the scan)
+		"-bulk-size", "25",       // process 25 URLs at a time so progress is visible
 		"-tags", strings.Join(t.nucleiURLTags(), ","),
 		"-severity", "critical,high,medium",
 		"-jsonl",
@@ -815,6 +837,8 @@ func (t *ToolBox) RunNucleiTakeovers(ctx context.Context, targetsFile string, ou
 		"-tags", "takeover",
 		"-c", strconv.Itoa(t.nucleiConcurrency()),
 		"-rl", strconv.Itoa(rateLimit),
+		"-timeout", "5",        // per-request timeout (seconds)
+		"-max-host-error", "3", // bail out of unresponsive hosts quickly
 		"-jsonl",
 		"-o", outputFile,
 	}
@@ -836,27 +860,7 @@ func (t *ToolBox) RunDalfox(ctx context.Context, inputFile string, outputFile st
 		"-o", outputFile,
 		"--silence",
 		"--no-color",
-	}
-	args = t.appendDalfoxUA(args)
-	args = t.appendProxy(args, "--proxy")
-	if rps := t.globalRPS(); rps > 0 {
-		delayMs := 1000 / rps
-		if delayMs < 1 {
-			delayMs = 1
-		}
-		args = append(args, "--delay", strconv.Itoa(delayMs))
-	}
-	_, err := t.Runner.Run(ctx, "dalfox", args)
-	return err
-}
-
-// RunDalfoxURL scans a single URL for XSS.
-func (t *ToolBox) RunDalfoxURL(ctx context.Context, targetURL string, outputFile string) error {
-	args := []string{
-		"url", targetURL,
-		"-o", outputFile,
-		"--silence",
-		"--no-color",
+		"--timeout", "10", // seconds per request; prevents hanging on blocked IPs
 	}
 	args = t.appendDalfoxUA(args)
 	args = t.appendProxy(args, "--proxy")
@@ -885,6 +889,7 @@ func (t *ToolBox) RunTlsx(ctx context.Context, inputFile string, outputFile stri
 		"-nc",
 		"-duc",
 		"-c", "50",
+		"-timeout", "5", // seconds per TLS handshake; prevents hanging on blocked hosts
 	}
 	_, err := t.Runner.Run(ctx, "tlsx", args)
 	return err
@@ -969,13 +974,15 @@ func (t *ToolBox) RunHttpxFingerprint(ctx context.Context, inputFile string, out
 // RunNucleiWAF runs Nuclei specifically for WAF detection with a conservative rate limit.
 func (t *ToolBox) RunNucleiWAF(ctx context.Context, inputFile string, outputFile string) error {
 	// WAF detection needs a gentler rate limit as sending malicious tags will quickly trigger blocks.
-	rateLimit := t.effectiveRate(50) 
+	rateLimit := t.effectiveRate(50)
 	concurrency := 10
 
 	args := []string{
 		"-l", inputFile,
 		"-c", strconv.Itoa(concurrency),
 		"-rl", strconv.Itoa(rateLimit),
+		"-timeout", "5",        // per-request timeout (seconds)
+		"-max-host-error", "3", // bail out of unresponsive hosts quickly
 		"-tags", "waf",
 		"-jsonl",
 		"-o", outputFile,

--- a/pkg/wildcard_flow/asset_discovery.go
+++ b/pkg/wildcard_flow/asset_discovery.go
@@ -39,6 +39,7 @@ func stepPassiveEnum(c *Ctx) bool {
 		go func() {
 			defer wg.Done()
 			logger.SubStep("[Start] Subfinder")
+			logger.FileDebug("subfinder input: domain=%s out=%s", c.Domain, c.F.SubfinderOut)
 			if err := c.Tb.RunSubfinder(sCtx, c.Domain, c.F.SubfinderOut); err != nil {
 				if sCtx.Err() == nil {
 					logger.Error("Subfinder failed: %v", err)
@@ -48,6 +49,7 @@ func stepPassiveEnum(c *Ctx) bool {
 				if c.ScanID > 0 {
 					count, _ := utils.ParseSubdomainsFile(c.ScanID, c.F.SubfinderOut, "subfinder")
 					logger.Info("  Found %d subdomains", count)
+					logger.FileDebug("subfinder raw lines in output: %d", count)
 				}
 			}
 		}()
@@ -55,6 +57,7 @@ func stepPassiveEnum(c *Ctx) bool {
 		go func() {
 			defer wg.Done()
 			logger.SubStep("[Start] Assetfinder")
+			logger.FileDebug("assetfinder input: domain=%s out=%s", c.Domain, c.F.AssetfinderOut)
 			if err := c.Tb.RunAssetfinder(sCtx, c.Domain, c.F.AssetfinderOut); err != nil {
 				if sCtx.Err() == nil {
 					logger.Error("Assetfinder failed: %v", err)
@@ -64,6 +67,7 @@ func stepPassiveEnum(c *Ctx) bool {
 				if c.ScanID > 0 {
 					count, _ := utils.ParseSubdomainsFile(c.ScanID, c.F.AssetfinderOut, "assetfinder")
 					logger.Info("  Found %d subdomains", count)
+					logger.FileDebug("assetfinder raw lines in output: %d", count)
 				}
 			}
 		}()
@@ -71,15 +75,18 @@ func stepPassiveEnum(c *Ctx) bool {
 		go func() {
 			defer wg.Done()
 			logger.SubStep("[Start] Sublist3r")
+			logger.FileDebug("sublist3r input: domain=%s out=%s", c.Domain, c.F.Sublist3rOut)
 			if err := c.Tb.RunSublist3r(sCtx, c.Domain, c.F.Sublist3rOut); err != nil {
 				if c.Verbose && sCtx.Err() == nil {
 					logger.Warning("Sublist3r failed: %v", err)
 				}
+				logger.FileDebug("sublist3r failed: %v", err)
 			} else {
 				logger.SubStep("[Done] Sublist3r")
 				if c.ScanID > 0 {
 					count, _ := utils.ParseSubdomainsFile(c.ScanID, c.F.Sublist3rOut, "sublist3r")
 					logger.Info("  Found %d subdomains", count)
+					logger.FileDebug("sublist3r raw lines in output: %d", count)
 				}
 			}
 		}()
@@ -108,6 +115,7 @@ func stepActiveEnum(c *Ctx) bool {
 	} else if !c.SkipAmass {
 		logger.StepHeader("Step 2: Active Subdomain Enumeration (Amass)")
 		logger.SubStep("Running Amass (this may take a while)...")
+		logger.FileDebug("amass input: domain=%s out=%s", c.Domain, c.F.AmassOut)
 		if err := runWithSkip(c, "amass", func(sCtx context.Context) error {
 			return c.Tb.RunAmass(sCtx, c.Domain, c.F.AmassOut)
 		}); err != nil {
@@ -122,11 +130,13 @@ func stepActiveEnum(c *Ctx) bool {
 			if c.ScanID > 0 {
 				count, _ := utils.ParseSubdomainsFile(c.ScanID, c.F.AmassOut, "amass")
 				logger.Info("  Found %d subdomains", count)
+				logger.FileDebug("amass raw lines in output: %d", count)
 			}
 			c.StateMgr.MarkStepComplete(c.State, "active_enum")
 		}
 	} else {
 		logger.StepHeader("Step 2: Skipping Amass (--skip-amass)")
+		logger.FileDebug("amass skipped via --skip-amass flag")
 		c.StateMgr.MarkStepComplete(c.State, "active_enum")
 	}
 	return c.cancelled()
@@ -144,6 +154,7 @@ func stepGitHubRecon(c *Ctx) bool {
 	} else if c.GitHubToken != "" {
 		logger.StepHeader("Step 3: GitHub Subdomain Discovery")
 		logger.SubStep("Running github-subdomains...")
+		logger.FileDebug("github-subdomains input: domain=%s token_len=%d out=%s", c.Domain, len(c.GitHubToken), c.F.GithubSubsOut)
 		if err := runWithSkip(c, "github-subdomains", func(sCtx context.Context) error {
 			return c.Tb.RunGithubSubdomains(sCtx, c.Domain, c.GitHubToken, c.F.GithubSubsOut)
 		}); err != nil {
@@ -157,12 +168,14 @@ func stepGitHubRecon(c *Ctx) bool {
 			if c.ScanID > 0 {
 				count, _ := utils.ParseSubdomainsFile(c.ScanID, c.F.GithubSubsOut, "github")
 				logger.Info("  Found %d subdomains", count)
+				logger.FileDebug("github-subdomains raw lines in output: %d", count)
 			}
 			logger.SubStep("[Done] GitHub Subdomains")
 		}
 	} else {
 		logger.StepHeader("Step 3: Skipping GitHub Recon (no token provided)")
 		logger.Warning("Set GITHUB_TOKEN env var or use --github-token for GitHub recon")
+		logger.FileDebug("github_recon skipped: no token provided")
 	}
 	c.StateMgr.MarkStepComplete(c.State, "github_recon")
 	return c.cancelled()

--- a/pkg/wildcard_flow/content_discovery.go
+++ b/pkg/wildcard_flow/content_discovery.go
@@ -56,10 +56,12 @@ func stepURLDiscovery(c *Ctx) bool {
 		go func() {
 			defer wg.Done()
 			logger.SubStep("[Start] Waybackurls")
+			logger.FileDebug("waybackurls input: domain=%s out=%s", c.Domain, c.F.WaybackOut)
 			if err := c.Tb.RunWaybackurls(sCtx, c.Domain, c.F.WaybackOut); err != nil {
 				if c.Verbose && sCtx.Err() == nil {
 					logger.Warning("Waybackurls failed: %v", err)
 				}
+				logger.FileDebug("waybackurls failed: %v", err)
 			} else {
 				resultMu.Lock()
 				waybackOK = true
@@ -68,6 +70,7 @@ func stepURLDiscovery(c *Ctx) bool {
 				if c.ScanID > 0 {
 					count, _ := utils.ParseURLsFile(c.ScanID, c.F.WaybackOut, "waybackurls")
 					logger.Info("  Found %d URLs", count)
+					logger.FileDebug("waybackurls output: %d URLs -> %s", count, c.F.WaybackOut)
 				}
 			}
 		}()
@@ -75,10 +78,12 @@ func stepURLDiscovery(c *Ctx) bool {
 		go func() {
 			defer wg.Done()
 			logger.SubStep("[Start] GAU")
+			logger.FileDebug("gau input: domain=%s out=%s", c.Domain, c.F.GauOut)
 			if err := c.Tb.RunGau(sCtx, c.Domain, c.F.GauOut); err != nil {
 				if c.Verbose && sCtx.Err() == nil {
 					logger.Warning("GAU failed: %v", err)
 				}
+				logger.FileDebug("gau failed: %v", err)
 			} else {
 				resultMu.Lock()
 				gauOK = true
@@ -87,6 +92,7 @@ func stepURLDiscovery(c *Ctx) bool {
 				if c.ScanID > 0 {
 					count, _ := utils.ParseURLsFile(c.ScanID, c.F.GauOut, "gau")
 					logger.Info("  Found %d URLs", count)
+					logger.FileDebug("gau output: %d URLs -> %s", count, c.F.GauOut)
 				}
 			}
 		}()
@@ -138,6 +144,9 @@ func stepWebCrawling(c *Ctx) bool {
 	crawlFailed := false
 	var crawlFailMu sync.Mutex
 
+	liveHostCount, _ := utils.CountFileLines(c.F.HttpxLiveHosts)
+	logger.FileDebug("web_crawling input: %s (%d live hosts)", c.F.HttpxLiveHosts, liveHostCount)
+
 	err := runWithSkip(c, "web crawling", func(sCtx context.Context) error {
 		var wg sync.WaitGroup
 		wg.Add(2)
@@ -145,6 +154,7 @@ func stepWebCrawling(c *Ctx) bool {
 		go func() {
 			defer wg.Done()
 			logger.SubStep("[Start] Katana")
+			logger.FileDebug("katana input: %s out=%s", c.F.HttpxLiveHosts, c.F.KatanaOut)
 			if err := c.Tb.RunKatana(sCtx, c.F.HttpxLiveHosts, c.F.KatanaOut); err != nil {
 				if sCtx.Err() == nil {
 					crawlFailMu.Lock()
@@ -157,6 +167,7 @@ func stepWebCrawling(c *Ctx) bool {
 				if c.ScanID > 0 {
 					count, _ := utils.ParseURLsFile(c.ScanID, c.F.KatanaOut, "katana")
 					logger.Info("  Katana found %d URLs", count)
+					logger.FileDebug("katana output: %d URLs -> %s", count, c.F.KatanaOut)
 				}
 			}
 		}()
@@ -164,6 +175,7 @@ func stepWebCrawling(c *Ctx) bool {
 		go func() {
 			defer wg.Done()
 			logger.SubStep("[Start] GoSpider")
+			logger.FileDebug("gospider input: %s out=%s", c.F.HttpxLiveHosts, c.F.GospiderOut)
 			if err := c.Tb.RunGoSpider(sCtx, c.F.HttpxLiveHosts, c.F.GospiderOut); err != nil {
 				if sCtx.Err() == nil {
 					crawlFailMu.Lock()
@@ -176,6 +188,7 @@ func stepWebCrawling(c *Ctx) bool {
 				if c.ScanID > 0 {
 					count, _ := utils.ParseURLsFile(c.ScanID, c.F.GospiderOut, "gospider")
 					logger.Info("  GoSpider found %d URLs", count)
+					logger.FileDebug("gospider output: %d URLs -> %s", count, c.F.GospiderOut)
 				}
 			}
 		}()
@@ -307,6 +320,7 @@ func stepURLConsolidation(c *Ctx) bool {
 
 	sources := c.urlSources()
 	logger.SubStep("Merging URLs from %d sources...", len(sources))
+	logger.FileDebug("url_consolidation sources: %v", sources)
 	if err := utils.MergeAndDeduplicate(sources, c.F.AllURLsRaw); err != nil {
 		c.StateMgr.MarkStepFailed(c.State, "url_consolidation", err)
 		logger.Warning("URL merge failed: %v", err)
@@ -318,10 +332,13 @@ func stepURLConsolidation(c *Ctx) bool {
 		}
 		rawCount, _ := utils.CountFileLines(c.F.AllURLsRaw)
 		logger.Info("  Merged %d unique URLs", rawCount)
+		logger.FileDebug("url_consolidation merged %d raw URLs -> %s", rawCount, c.F.AllURLsRaw)
 	}
 
 	// Live-check all URLs with httpx
 	logger.SubStep("Running httpx to live-check all URLs...")
+	rawCount2, _ := utils.CountFileLines(c.F.AllURLsRaw)
+	logger.FileDebug("httpx_url_check input: %s (%d URLs) out=%s", c.F.AllURLsRaw, rawCount2, c.F.AllURLsLive)
 	if err := runWithSkip(c, "httpx (URL check)", func(sCtx context.Context) error {
 		return c.Tb.RunHttpxURLCheck(sCtx, c.F.AllURLsRaw, c.F.AllURLsLive)
 	}); err != nil {
@@ -337,6 +354,7 @@ func stepURLConsolidation(c *Ctx) bool {
 	} else {
 		liveCount, _ := utils.CountFileLines(c.F.AllURLsLive)
 		logger.Success("  %d live URLs confirmed", liveCount)
+		logger.FileDebug("httpx_url_check output: %d live URLs -> %s", liveCount, c.F.AllURLsLive)
 	}
 
 	// Persist live URLs into DB so GetScanStats / query commands reflect reality.
@@ -532,6 +550,7 @@ func stepDirFuzzing(c *Ctx) bool {
 		logger.StepHeader("Step 17: Directory Fuzzing (ffuf)")
 		targetURL := fmt.Sprintf("https://%s/FUZZ", c.Domain)
 		logger.SubStep("Running ffuf with wordlist: %s", c.WordlistPath)
+		logger.FileDebug("ffuf input: target=%s wordlist=%s out=%s", targetURL, c.WordlistPath, c.F.FfufOut)
 
 		if err := runWithSkip(c, "ffuf", func(sCtx context.Context) error {
 			return c.Tb.RunFfufWithFUZZ(sCtx, targetURL, c.WordlistPath, c.F.FfufOut)

--- a/pkg/wildcard_flow/flow.go
+++ b/pkg/wildcard_flow/flow.go
@@ -61,10 +61,16 @@ type RunConfig struct {
 	GitHubToken     string
 
 	// Control parameters
-	ResumeScanID   int64
+	ResumeScanID int64
 
 	// Post-scan
 	GenerateReport bool
+
+	// Logging
+	// SaveLog controls whether scan output is mirrored to a log file in
+	// ~/.chaathan/logs/ (plain text, ANSI stripped). The filename is
+	// generated automatically as <domain>_<scanID>_<timestamp>.log.
+	SaveLog bool
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -207,6 +213,9 @@ type Ctx struct {
 
 	// WAF evasion
 	Proxy string // proxy URL for collector.go (from config or CLI override)
+
+	// Log file path (set when SaveLog is true and file opened successfully)
+	LogFilePath string
 }
 
 // cancelled returns true when the parent context has been cancelled.
@@ -292,6 +301,24 @@ func Run(cfg RunConfig) error {
 		scanID = dbScan.ID
 	}
 
+	// ── File logging ──────────────────────────────────────
+	// logFilePath is declared here so it outlives the if-block and can be
+	// stored on Ctx for display in next-steps at scan end.
+	var logFilePath string
+	if cfg.SaveLog {
+		timestamp := startTime.Format("20060102_150405")
+		logFileName := fmt.Sprintf("%s_%d_%s.log", cfg.Domain, scanID, timestamp)
+		logFilePath = filepath.Join(paths.LogsDir(), logFileName)
+		if err := logger.InitFileLog(logFilePath); err != nil {
+			logger.Warning("Could not open log file: %v", err)
+			logFilePath = "" // clear so Ctx doesn't show a broken path
+		} else {
+			logger.WriteLogHeader(cfg.Domain, scanID, logFilePath)
+			logger.Info("Scan log: %s", logFilePath)
+			defer logger.CloseFileLog()
+		}
+	}
+
 	// ── Scan header & state ──────────────────────────────────
 	logger.ScanHeader("Wildcard", cfg.Domain, scanID)
 	logger.InitScanUI(len(scan.WildcardSteps))
@@ -337,6 +364,7 @@ func Run(cfg RunConfig) error {
 		Notifier:           infra.Notifier,
 		F:                  newFiles(cfg.ResultDir),
 		NotifyStepComplete: cfg.Cfg != nil && cfg.Cfg.Notifications.StepComplete,
+		LogFilePath:        logFilePath,
 	}
 
 	// Wire proxy from config
@@ -583,10 +611,14 @@ func finalizeScan(c *Ctx, status string) {
 	}
 
 	if c.ScanID > 0 {
-		logger.NextSteps([]string{
+		hints := []string{
 			fmt.Sprintf("chaathan scans show %d       # View scan details", c.ScanID),
 			fmt.Sprintf("chaathan query vulns %d      # List vulnerabilities", c.ScanID),
 			fmt.Sprintf("chaathan report generate %d  # Generate full report", c.ScanID),
-		})
+		}
+		if c.LogFilePath != "" {
+			hints = append([]string{fmt.Sprintf("cat %s  # full scan log", c.LogFilePath)}, hints...)
+		}
+		logger.NextSteps(hints)
 	}
 }

--- a/pkg/wildcard_flow/validation.go
+++ b/pkg/wildcard_flow/validation.go
@@ -43,6 +43,7 @@ func stepDNSConsolidation(c *Ctx) bool {
 		c.F.HakrawlerOut,
 		c.F.UncoverHostsOut, // hostnames extracted from uncover.json in Step 4
 	)
+	logger.FileDebug("dns_consolidation: %d passive source files available (subfinder, assetfinder, sublist3r, amass, github, hakrawler, uncover_hosts)", len(passiveSources))
 	if err := utils.MergeAndDeduplicate(passiveSources, c.F.ConsolidatedSubs); err != nil {
 		c.StateMgr.MarkStepFailed(c.State, "dns_resolution", err)
 		logger.Error("Failed to consolidate: %v", err)
@@ -50,8 +51,10 @@ func stepDNSConsolidation(c *Ctx) bool {
 	}
 	subCount, _ := utils.CountFileLines(c.F.ConsolidatedSubs)
 	logger.Success("Consolidated %d unique subdomains", subCount)
+	logger.FileDebug("consolidated subs total: %d -> %s", subCount, c.F.ConsolidatedSubs)
 
 	logger.SubStep("Running DNSx for resolution...")
+	logger.FileDebug("dnsx input: %s (%d lines) out=%s", c.F.ConsolidatedSubs, subCount, c.F.DnsxOut)
 	if err := runWithSkip(c, "dnsx", func(sCtx context.Context) error {
 		return c.Tb.RunDnsx(sCtx, c.F.ConsolidatedSubs, c.F.DnsxOut)
 	}); err != nil {
@@ -64,6 +67,7 @@ func stepDNSConsolidation(c *Ctx) bool {
 	} else {
 		resolvedCount, _ := utils.CountFileLines(c.F.DnsxOut)
 		logger.Info("  Resolved %d subdomains via DNS", resolvedCount)
+		logger.FileDebug("dnsx output: %d resolved records -> %s", resolvedCount, c.F.DnsxOut)
 	}
 	c.StateMgr.MarkStepComplete(c.State, "dns_resolution")
 	return c.cancelled()
@@ -81,6 +85,8 @@ func stepDNSBruteforce(c *Ctx) bool {
 	} else if !c.SkipShuffleDNS && c.DNSWordlistPath != "" {
 		logger.StepHeader("Step 7: DNS Brute-force (ShuffleDNS)")
 		logger.SubStep("Running ShuffleDNS with wordlist: %s", c.DNSWordlistPath)
+		logger.FileDebug("shuffledns input: domain=%s wordlist=%s resolvers=%s out=%s",
+			c.Domain, c.DNSWordlistPath, c.ResolversPath, c.F.ShufflednsOut)
 
 		if err := runWithSkip(c, "shuffledns", func(sCtx context.Context) error {
 			return c.Tb.RunShuffleDNS(sCtx, c.Domain, c.DNSWordlistPath, c.ResolversPath, c.F.ShufflednsOut)
@@ -95,20 +101,26 @@ func stepDNSBruteforce(c *Ctx) bool {
 			if c.ScanID > 0 {
 				count, _ := utils.ParseSubdomainsFile(c.ScanID, c.F.ShufflednsOut, "shuffledns")
 				logger.Info("  Found %d subdomains via DNS brute-force", count)
+				logger.FileDebug("shuffledns output: %d subdomains -> %s", count, c.F.ShufflednsOut)
 			}
 			// Merge brute-forced subs back into the consolidated list
 			utils.MergeAndDeduplicate(
 				[]string{c.F.ConsolidatedSubs, c.F.ShufflednsOut},
 				c.F.ConsolidatedSubs,
 			)
+			if merged, _ := utils.CountFileLines(c.F.ConsolidatedSubs); merged > 0 {
+				logger.FileDebug("consolidated subs after shuffledns merge: %d", merged)
+			}
 		}
 		c.StateMgr.MarkStepComplete(c.State, "dns_bruteforce")
 	} else if c.SkipShuffleDNS {
 		logger.StepHeader("Step 7: Skipping ShuffleDNS (--skip-shuffledns)")
+		logger.FileDebug("shuffledns skipped via --skip-shuffledns flag")
 		c.StateMgr.MarkStepComplete(c.State, "dns_bruteforce")
 	} else {
 		logger.StepHeader("Step 7: Skipping ShuffleDNS (no --dns-wordlist provided)")
 		logger.Info("Use --dns-wordlist to enable DNS brute-force")
+		logger.FileDebug("shuffledns skipped: no --dns-wordlist provided")
 		c.StateMgr.MarkStepComplete(c.State, "dns_bruteforce")
 	}
 	return c.cancelled()
@@ -127,6 +139,8 @@ func stepHTTPProbing(c *Ctx) bool {
 	}
 	logger.StepHeader("Step 8: Live Web Server Probing")
 	logger.SubStep("Running Httpx...")
+	hostInputCount, _ := utils.CountFileLines(c.F.ConsolidatedSubs)
+	logger.FileDebug("httpx input: %s (%d hosts) out=%s", c.F.ConsolidatedSubs, hostInputCount, c.F.HttpxOut)
 
 	if err := runWithSkip(c, "httpx", func(sCtx context.Context) error {
 		return c.Tb.RunHttpx(sCtx, c.F.ConsolidatedSubs, c.F.HttpxOut)
@@ -144,6 +158,7 @@ func stepHTTPProbing(c *Ctx) bool {
 		if count > 0 {
 			logger.Info("  Found %d live hosts", count)
 		}
+		logger.FileDebug("httpx output: %d live hosts -> %s", count, c.F.HttpxOut)
 	}
 	c.StateMgr.MarkStepComplete(c.State, "http_probing")
 	return c.cancelled()
@@ -161,6 +176,8 @@ func stepTLSAnalysis(c *Ctx) bool {
 	} else if !c.SkipTlsx {
 		logger.StepHeader("Step 9: TLS Certificate Analysis (tlsx)")
 		logger.SubStep("Running tlsx — extracting SANs and checking cert issues...")
+		inputCount, _ := utils.CountFileLines(c.F.ConsolidatedSubs)
+		logger.FileDebug("tlsx input: %s (%d hosts) out=%s", c.F.ConsolidatedSubs, inputCount, c.F.TlsxOut)
 
 		if err := runWithSkip(c, "tlsx", func(sCtx context.Context) error {
 			return c.Tb.RunTlsx(sCtx, c.F.ConsolidatedSubs, c.F.TlsxOut)
@@ -228,6 +245,8 @@ func stepPortScanning(c *Ctx) bool {
 	} else if !c.SkipNaabu {
 		logger.StepHeader("Step 10: Port Scanning")
 		logger.SubStep("Running Naabu on all discovered subdomains...")
+		inputCount, _ := utils.CountFileLines(c.F.ConsolidatedSubs)
+		logger.FileDebug("naabu input: %s (%d hosts) out=%s", c.F.ConsolidatedSubs, inputCount, c.F.NaabuOut)
 
 		if err := runWithSkip(c, "naabu", func(sCtx context.Context) error {
 			return c.Tb.RunNaabuList(sCtx, c.F.ConsolidatedSubs, c.F.NaabuOut)

--- a/pkg/wildcard_flow/vulnerability_scanning.go
+++ b/pkg/wildcard_flow/vulnerability_scanning.go
@@ -33,8 +33,10 @@ func stepVulnScanningInfra(c *Ctx) bool {
 		liveHostCount := collectLiveHostTargetsFromHttpx(c.F.HttpxOut, c.F.HttpxLiveHosts)
 		if liveHostCount == 0 {
 			logger.Info("  Skipping Nuclei infra scan (no live httpx hosts available)")
+			logger.FileDebug("nuclei_infra skipped: httpx output has 0 live hosts (%s)", c.F.HttpxOut)
 		} else {
 			logger.SubStep("Running Nuclei on %d live httpx hosts...", liveHostCount)
+			logger.FileDebug("nuclei_infra input: %s (%d hosts) out=%s", c.F.HttpxLiveHosts, liveHostCount, c.F.NucleiOut)
 
 			// Snapshot existing vuln IDs before Nuclei so we only notify
 			// about genuinely new findings (avoids flooding on resume).
@@ -55,6 +57,7 @@ func stepVulnScanningInfra(c *Ctx) bool {
 				count, _ := utils.ParseNucleiOutput(c.ScanID, c.F.NucleiOut)
 				if count > 0 {
 					logger.Info("  Found %d vulnerabilities", count)
+					logger.FileDebug("nuclei_infra output: %d findings -> %s", count, c.F.NucleiOut)
 					// Notify critical/high findings immediately
 					if c.Notifier != nil {
 						sendVulnNotifications(c, notify.Finding{
@@ -110,6 +113,7 @@ func stepVulnScanningURLs(c *Ctx) bool {
 			}
 			if gfCount > 0 {
 				logger.Info("  gf matched %d URLs across Tier 1 patterns", gfCount)
+				logger.FileDebug("gf_tier1 output: %d URL matches -> %s", gfCount, c.F.NucleiGFMatches)
 			} else {
 				logger.Info("  gf found no matches; skipping Nuclei URL scan")
 			}
@@ -127,8 +131,10 @@ func stepVulnScanningURLs(c *Ctx) bool {
 
 		if urlTargetCount == 0 {
 			logger.Info("  Skipping Nuclei URL scan (no gf-matched URLs available)")
+			logger.FileDebug("nuclei_urls skipped: 0 gf-matched URL targets")
 		} else {
 			logger.SubStep("Running Nuclei on %d gf-matched URLs...", urlTargetCount)
+			logger.FileDebug("nuclei_urls input: %s (%d URLs) out=%s", c.F.NucleiURLTargets, urlTargetCount, c.F.NucleiURLOut)
 
 			if err := runWithSkip(c, "nuclei (URLs)", func(sCtx context.Context) error {
 				return c.Tb.RunNucleiURLs(sCtx, c.F.NucleiURLTargets, c.F.NucleiURLOut)
@@ -235,6 +241,7 @@ func stepXSSScanning(c *Ctx) bool {
 
 		if paramCount > 0 {
 			logger.Info("  Found %d parameterized URLs to test", paramCount)
+			logger.FileDebug("dalfox input: %s (%d param URLs) out=%s", c.F.ParamURLsFile, paramCount, c.F.DalfoxOut)
 			logger.SubStep("Running Dalfox on parameterized URLs...")
 
 			if err := runWithSkip(c, "dalfox", func(sCtx context.Context) error {


### PR DESCRIPTION
Add an optional --log flag and SaveLog config to mirror scan output to ~/.chaathan/logs as plain-text (ANSI stripped). Implement a file-logging tee (InitFileLog/CloseFileLog, logWrite, WriteLogHeader, LogCommand, LogToolFailure, FileDebug) that prefixes timestamps and strips ANSI sequences. Wire file logging into Run to open the log, write a header, and expose the log path in final NextSteps. Always record exact tool commands and failures to the file from the runner. Add many FileDebug calls across the wildcard flow to capture inputs/outputs and counts for easier post-mortem. Also add LogsDir helper. Other improvements: Python tool installer now forces urllib3 reinstall for sublist3r/arjun to avoid urllib3 v2 breakage; tune various tool arguments (timeouts, retries, bulk sizes, tags) and adjust nuclei tag/severity defaults to reduce noise.