### PR TITLE
update docs

### DIFF
--- a/.agents/skills/chaathan-code-review/SKILL.md
+++ b/.agents/skills/chaathan-code-review/SKILL.md
@@ -40,7 +40,7 @@ Review for breakage in this order:
 - Report field added in one format but missing from others
 - ROI score changed without updating `Reasons`
 - Setup installs a tool but `tools check` or runtime still disagrees
-- Step counts/help text drift from actual workflow (21 steps, 4 phases)
+- Step counts/help text drift from actual workflow (22 steps, 5 phases)
 - Step function returns hard-coded `false` instead of `c.cancelled()`
 - `MarkStepComplete` called after `MarkStepFailed` in same error path
 - Resume path (`IsStepCompleted` early return) returns `false` instead of `c.cancelled()`

--- a/.agents/skills/chaathan-dev/SKILL.md
+++ b/.agents/skills/chaathan-dev/SKILL.md
@@ -62,6 +62,7 @@ pkg/utils/           → file I/O, parsers, export helpers, validation, formatti
 - Every step function must return `c.cancelled()`, never `return false`.
 - Never call `MarkStepComplete` after `MarkStepFailed` in the same error path.
 - `WildcardSteps` in `pkg/scan/scan.go` must match execution order in `flow.go`.
+- `SaveLog` (`--log` flag) mirrors scan output to `~/.chaathan/logs/<domain>_<scanID>_<timestamp>.log`. The log path is stored on `Ctx.LogFilePath` and shown in next-steps hints. Any new logging option follows the same pattern: add to `RunConfig`, open file in `Run()`, store path on `Ctx`.
 
 ## Validation
 

--- a/.agents/skills/chaathan-recon-workflows/SKILL.md
+++ b/.agents/skills/chaathan-recon-workflows/SKILL.md
@@ -14,6 +14,7 @@ Activate this skill when the task touches recon pipeline behavior rather than ge
 ### Wildcard flow (`pkg/wildcard_flow/`)
 
 - `RunConfig` — boundary from CLI into workflow code (all CLI options).
+  - Includes `SaveLog bool` — when true, mirrors full scan output to `~/.chaathan/logs/<domain>_<scanID>_<timestamp>.log` (plain text, ANSI stripped). File path stored in `Ctx.LogFilePath` and shown in next-steps hints after the scan.
 - `Files` — canonical artifact paths for the run (`intermediate_files/` and `final_files/`).
 - `Ctx` — shared execution state embedding `RunConfig`: tools, scan state, notifier, paths.
 - Each step lives in a phase-aligned file.
@@ -40,7 +41,7 @@ Phase 5 — Fingerprinting       (Step 22)     in: live hosts     out: Tech/WAF 
 | 2 | `active_enum` | Amass | `--skip-amass` |
 | 3 | `github_recon` | github-subdomains | needs `--github-token` |
 | 4 | `search_engine_recon` | Uncover | `--skip-uncover` |
-| 5 | `js_subdomain_discovery` | SubDomainizer | `--skip-subdomainizer` |
+| 5 | `js_subdomain_discovery` | Hakrawler | `--skip-hakrawler` |
 
 ### Phase 2 — Validation (`validation.go`)
 
@@ -70,7 +71,7 @@ Phase 5 — Fingerprinting       (Step 22)     in: live hosts     out: Tech/WAF 
 |------|------|---------|-------|
 | 18 | `vuln_scanning` | Nuclei (infra) | `--skip-nuclei` |
 | 19 | `vuln_scanning_urls` | Nuclei (URLs + gf) | `--skip-nuclei` |
-| 20 | `takeover_detection` | Subjack | `--skip-subjack` |
+| 20 | `takeover_detection` | Nuclei (takeover templates) | `--skip-takeovers` |
 | 21 | `xss_scanning` | Dalfox | `--skip-dalfox` |
 
 ### Phase 5 — Fingerprinting (`fingerprinting.go`)

--- a/.agents/skills/chaathan-tooling-setup/SKILL.md
+++ b/.agents/skills/chaathan-tooling-setup/SKILL.md
@@ -36,10 +36,10 @@ Activate this skill for tasks involving external binary installation, setup beha
 | DNS | dnsx, shuffledns, massdns |
 | Probe | httpx, tlsx, naabu |
 | URLs | waybackurls, gau, arjun |
-| Crawl | katana, gospider |
-| Analysis | linkfinder, subdomainizer |
+| Crawl | katana, gospider, hakrawler |
+| Analysis | GoLinkFinder |
 | Fuzz | ffuf |
-| Vuln | nuclei, subjack, dalfox |
+| Vuln | nuclei, dalfox |
 | Recon | uncover, metabigor, github-subdomains |
 | Cloud | cloud_enum |
 | Util | anew, gf |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ chaathan wildcard -d target.com --proxy socks5://127.0.0.1:9050 --rate-limit 10
 chaathan wildcard -d target.com --resume <scan_id>
 ```
 
+**Save scan output to a log file:**
+```bash
+chaathan wildcard -d target.com --log
+```
+Writes a plain-text, ANSI-stripped copy of the full scan output to `~/.chaathan/logs/<domain>_<scanID>_<timestamp>.log`. Useful for debugging or archiving scan sessions.
+
 Press **`s`** during scanning to skip the current tool without aborting.
 
 ### Company Scan (3 Steps)
@@ -137,6 +143,7 @@ chaathan company -n "Company Inc"
 | `chaathan wildcard -d <domain>` | 22-step domain recon workflow |
 | `chaathan wildcard -d <domain> --proxy <url>` | Scan through a proxy |
 | `chaathan wildcard -d <domain> --rate-limit <n>` | Cap all tools to N req/sec |
+| `chaathan wildcard -d <domain> --log` | Mirror scan output to `~/.chaathan/logs/` |
 | `chaathan company -n <name>` | 3-step company discovery workflow |
 
 ### Data & Results
@@ -404,7 +411,7 @@ chaathan setup --update       # reinstall all tools (force update to latest)
 │       ├── final_files/         # Consolidated product files
 │       │   ├── nuclei_vulns.json
 │       │   ├── gf_secrets_findings.txt
-│       │   └── dalfox_xss.json
+│       │   └── dalfox_xss.jsonl
 │       ├── SUMMARY.txt
 │       └── REPORT.md
 ├── reports/

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -42,7 +42,7 @@ type Step struct {
 }
 
 // WildcardSteps defines the steps in the wildcard workflow.
-// Order matches the 4-phase execution sequence in pkg/wildcard_flow/flow.go:
+// Order matches the 5-phase execution sequence in pkg/wildcard_flow/flow.go:
 //
 //	Phase 1 (Asset Discovery):   passive_enum, active_enum, github_recon, search_engine_recon, js_subdomain_discovery
 //	Phase 2 (Validation):        dns_resolution, dns_bruteforce, http_probing, tls_analysis, port_scanning


### PR DESCRIPTION
Document the new --log/SaveLog behavior and align docs and code with recent workflow/tooling changes. Added notes that --log mirrors plain-text scan output to ~/.chaathan/logs/<domain>_<scanID>_<timestamp>.log and that the path is stored on Ctx.LogFilePath and wired via RunConfig. Updated wildcard workflow metadata: step counts changed to 22 steps / 5 phases, WildcardSteps comment in pkg/scan/scan.go updated accordingly, js_subdomain_discovery now uses Hakrawler (not SubDomainizer), takeover_detection uses Nuclei takeover templates (removed Subjack), and tooling lists updated (added hakrawler and GoLinkFinder; removed subjack). Adjusted README to include --log usage and changed final artifact name for dalfox output to dalfox_xss.jsonl. Minor docs alignment in code-review skill to reflect step/phase counts.