### PR TITLE
Add scope filtering and config-driven tools

### DIFF
--- a/cli/wildcard.go
+++ b/cli/wildcard.go
@@ -158,6 +158,22 @@ func runWildcard(cmd *cobra.Command, args []string) {
 		Cfg.RateLimits.GlobalRPS = rateLimitRPS
 	}
 
+	// Resolve wordlist/resolver paths: CLI flag > config > empty (step skips)
+	wl := wordlistPath
+	if wl == "" && Cfg != nil && Cfg.General.Wordlists.Directories != "" {
+		wl = Cfg.General.Wordlists.Directories
+	}
+
+	dnsWl := dnsWordlistPath
+	if dnsWl == "" && Cfg != nil && Cfg.General.Wordlists.Subdomains != "" {
+		dnsWl = Cfg.General.Wordlists.Subdomains
+	}
+
+	resolvers := resolversPath
+	if resolvers == "" && Cfg != nil && Cfg.General.ResolversFile != "" {
+		resolvers = Cfg.General.ResolversFile
+	}
+
 	// Build configuration and delegate to the wildcard_flow package
 	cfg := wf.RunConfig{
 		Domain:            targetDomain,
@@ -177,9 +193,9 @@ func runWildcard(cmd *cobra.Command, args []string) {
 		SkipShuffleDNS:    skipShuffleDNS,
 		SkipHakrawler:     skipHakrawler,
 		SkipFingerprint:   skipFingerprint,
-		WordlistPath:      wordlistPath,
-		DNSWordlistPath:   dnsWordlistPath,
-		ResolversPath:     resolversPath,
+		WordlistPath:      wl,
+		DNSWordlistPath:   dnsWl,
+		ResolversPath:     resolvers,
 		GitHubToken:       token,
 		ResumeScanID:      resumeScanID,
 		GenerateReport:    generateReport,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,9 +38,6 @@ type GeneralConfig struct {
 	// Enable verbose logging
 	Verbose bool `yaml:"verbose"`
 
-	// Number of concurrent tools to run
-	Concurrency int `yaml:"concurrency"`
-
 	// Retry configuration
 	MaxRetries    int `yaml:"max_retries"`     // number of retries for failed tools (default: 1)
 	RetryDelaySec int `yaml:"retry_delay_sec"` // seconds between retries (default: 3)
@@ -98,18 +95,11 @@ type APIKeysConfig struct {
 	// SecurityTrails API key
 	SecurityTrails string `yaml:"securitytrails"`
 
-	// VirusTotal API key
+	// VirusTotal API key (also passed to subfinder as provider key)
 	VirusTotal string `yaml:"virustotal"`
 
-	// Chaos API key (ProjectDiscovery)
+	// Chaos API key (ProjectDiscovery; also passed to subfinder as provider key)
 	Chaos string `yaml:"chaos"`
-
-	// Hunter.io API key
-	Hunter string `yaml:"hunter"`
-
-	// PassiveTotal API credentials
-	PassiveTotalUser string `yaml:"passivetotal_user"`
-	PassiveTotalKey  string `yaml:"passivetotal_key"`
 }
 
 type ToolsConfig struct {
@@ -189,19 +179,6 @@ type NotificationConfig struct {
 
 	// Generic webhook URL
 	WebhookURL string `yaml:"webhook_url"`
-
-	// Email settings
-	Email EmailConfig `yaml:"email"`
-}
-
-type EmailConfig struct {
-	Enabled  bool   `yaml:"enabled"`
-	SMTPHost string `yaml:"smtp_host"`
-	SMTPPort int    `yaml:"smtp_port"`
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
-	From     string `yaml:"from"`
-	To       string `yaml:"to"`
 }
 
 type ScopeConfig struct {
@@ -298,7 +275,6 @@ func DefaultConfig() *Config {
 			DatabasePath: filepath.Join(chaathanDir, "chaathan.db"),
 			Mode:         "native",
 			Verbose:      false,
-			Concurrency:  5,
 			Wordlists: WordlistsConfig{
 				Subdomains:  "/usr/share/wordlists/seclists/Discovery/DNS/subdomains-top1million-5000.txt",
 				Directories: "/usr/share/wordlists/seclists/Discovery/Web-Content/common.txt",
@@ -357,9 +333,6 @@ func DefaultConfig() *Config {
 }
 
 func applyDefaults(cfg *Config) {
-	if cfg.General.Concurrency == 0 {
-		cfg.General.Concurrency = 5
-	}
 	if cfg.General.Mode == "" {
 		cfg.General.Mode = "native"
 	}

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -303,7 +303,23 @@ func (t *ToolBox) RunSubfinder(ctx context.Context, domain string, outputFile st
 		"-timeout", strconv.Itoa(t.subfinderTimeout()),
 		"-o", outputFile,
 	}
-	_, err := t.Runner.Run(ctx, "subfinder", args)
+
+	// Pass API keys as env vars so subfinder picks them up as provider keys.
+	var opts []runner.Option
+	if t.APIKeys != nil {
+		var envVars []string
+		if t.APIKeys.VirusTotal != "" {
+			envVars = append(envVars, "VT_API_KEY="+t.APIKeys.VirusTotal)
+		}
+		if t.APIKeys.Chaos != "" {
+			envVars = append(envVars, "PDCP_API_KEY="+t.APIKeys.Chaos)
+		}
+		if len(envVars) > 0 {
+			opts = append(opts, runner.WithEnv(envVars...))
+		}
+	}
+
+	_, err := t.Runner.Run(ctx, "subfinder", args, opts...)
 	return err
 }
 
@@ -625,6 +641,10 @@ func (t *ToolBox) RunGoLinkFinder(ctx context.Context, url string, outputFile st
 // RunArjun discovers hidden HTTP parameters from a file of URLs (replaces single URL version)
 func (t *ToolBox) RunArjun(ctx context.Context, inputFile string, outputFile string) error {
 	args := []string{"-i", inputFile, "-oJ", outputFile, "--stable"}
+	// Use configured parameters wordlist if available
+	if t.General != nil && t.General.Wordlists.Parameters != "" {
+		args = append(args, "-w", t.General.Wordlists.Parameters)
+	}
 	args = t.appendArjunUA(args)
 	_, err := t.Runner.Run(ctx, "arjun", args)
 	return err
@@ -633,6 +653,10 @@ func (t *ToolBox) RunArjun(ctx context.Context, inputFile string, outputFile str
 // RunArjunFromFile discovers hidden HTTP parameters from a file of URLs
 func (t *ToolBox) RunArjunFromFile(ctx context.Context, inputFile string, outputFile string) error {
 	args := []string{"-i", inputFile, "-oJ", outputFile, "--stable"}
+	// Use configured parameters wordlist if available
+	if t.General != nil && t.General.Wordlists.Parameters != "" {
+		args = append(args, "-w", t.General.Wordlists.Parameters)
+	}
 	args = t.appendArjunUA(args)
 	_, err := t.Runner.Run(ctx, "arjun", args)
 	return err

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -97,6 +97,41 @@ func CountFileLines(filePath string) (int, error) {
 	return count, scanner.Err()
 }
 
+// FilterFileLines reads a file, keeps only lines where keep() returns true,
+// and writes the result back in place. Empty lines are always dropped.
+func FilterFileLines(filePath string, keep func(string) bool) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+
+	var kept []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" && keep(line) {
+			kept = append(kept, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		file.Close()
+		return err
+	}
+	file.Close()
+
+	f, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := bufio.NewWriter(f)
+	for _, line := range kept {
+		w.WriteString(line)
+		w.WriteByte('\n')
+	}
+	return w.Flush()
+}
+
 // SanitizeURLFile reads a URL file, cleans each line (unescaping unicode,
 // stripping non-URL lines), and writes the result back in place.
 // This prevents downstream tools (Nuclei, Dalfox, httpx) from receiving

--- a/pkg/wildcard_flow/flow.go
+++ b/pkg/wildcard_flow/flow.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vishnu303/chaathan-flow/pkg/paths"
 	"github.com/vishnu303/chaathan-flow/pkg/report"
 	"github.com/vishnu303/chaathan-flow/pkg/scan"
+	"github.com/vishnu303/chaathan-flow/pkg/scope"
 	"github.com/vishnu303/chaathan-flow/pkg/tools"
 	"github.com/vishnu303/chaathan-flow/pkg/utils"
 )
@@ -204,6 +205,7 @@ type Ctx struct {
 	StateMgr *scan.Manager
 	State    *scan.State
 	Notifier *notify.Notifier
+	ScopeFilter *scope.Scope // compiled scope rules from config (nil = no filtering)
 
 	// All file paths
 	F Files
@@ -374,6 +376,19 @@ func Run(cfg RunConfig) error {
 
 	logger.Info("💡 Press 's' at any time to skip the current tool")
 	logger.Info("Mode: %s", cfg.Mode)
+
+	// Wire scope from config
+	if cfg.Cfg != nil {
+		sc, err := scope.New(&cfg.Cfg.Scope)
+		if err != nil {
+			logger.Warning("Failed to compile scope rules: %v", err)
+		} else {
+			c.ScopeFilter = sc
+			if summary := sc.Summary(); summary != "All domains in scope" {
+				logger.Info("Scope: %s", summary)
+			}
+		}
+	}
 
 	// ── Step registry ───────────────────────────────────────
 	// Each entry maps a scan.WildcardSteps name to its implementation.

--- a/pkg/wildcard_flow/validation.go
+++ b/pkg/wildcard_flow/validation.go
@@ -53,6 +53,19 @@ func stepDNSConsolidation(c *Ctx) bool {
 	logger.Success("Consolidated %d unique subdomains", subCount)
 	logger.FileDebug("consolidated subs total: %d -> %s", subCount, c.F.ConsolidatedSubs)
 
+	// Apply scope filtering (removes out-of-scope subdomains before DNS resolution)
+	if c.ScopeFilter != nil {
+		if err := utils.FilterFileLines(c.F.ConsolidatedSubs, func(line string) bool {
+			return c.ScopeFilter.IsInScope(line) && !c.ScopeFilter.IsOutOfScope(line)
+		}); err == nil {
+			afterCount, _ := utils.CountFileLines(c.F.ConsolidatedSubs)
+			if filtered := subCount - afterCount; filtered > 0 {
+				logger.Info("  Filtered %d out-of-scope subdomains", filtered)
+				logger.FileDebug("scope filter: %d -> %d subdomains", subCount, afterCount)
+			}
+		}
+	}
+
 	logger.SubStep("Running DNSx for resolution...")
 	logger.FileDebug("dnsx input: %s (%d lines) out=%s", c.F.ConsolidatedSubs, subCount, c.F.DnsxOut)
 	if err := runWithSkip(c, "dnsx", func(sCtx context.Context) error {


### PR DESCRIPTION
Wire scope rules into wildcard flow and filter discovered subdomains by scope; resolve wordlist/resolver paths from config when CLI flags are empty; pass provider API keys to subfinder via env; use configured parameters wordlist for Arjun; add a reusable FilterFileLines utility. Also remove deprecated General.Concurrency and Email config fields and adjust defaults.

Changes include:
- CLI: fallback to config for wordlists, DNS wordlist and resolvers when flags are not provided.
- Flow: import scope, attach compiled scope to context, and log scope summary.
- Validation: apply scope filtering to consolidated subdomains before DNS resolution.
- Tools: set VT and Chaos provider keys as env vars for subfinder; Arjun now uses configured parameters wordlist if present.
- Utils: add FilterFileLines to filter file contents in-place.
- Config: remove General.Concurrency and Email-related config fields and related defaults/apply logic.