### PR TITLE
Add Linux PATH handling and trim VERSION newline

### DIFF
--- a/pkg/setup/go_installer.go
+++ b/pkg/setup/go_installer.go
@@ -17,6 +17,17 @@ import (
 
 // CheckGoInstalledAndAtLeast126 checks if go is in PATH and if its version is >= 1.26.
 func CheckGoInstalledAndAtLeast126() (bool, string) {
+	if runtime.GOOS == "linux" {
+		currentPath := os.Getenv("PATH")
+		goBin := "/usr/local/go/bin"
+		if !strings.Contains(currentPath, goBin) {
+			if _, err := os.Stat("/usr/local/go/bin/go"); err == nil {
+				currentPath = currentPath + string(os.PathListSeparator) + goBin
+				_ = os.Setenv("PATH", currentPath)
+			}
+		}
+	}
+
 	path, err := exec.LookPath("go")
 	if err != nil {
 		return false, ""
@@ -67,6 +78,9 @@ func downloadLatestGo(ctx *SetupContext) (string, error) {
 		return "go1.26.0", nil
 	}
 	version := strings.TrimSpace(string(body))
+	if idx := strings.Index(version, "\n"); idx >= 0 {
+		version = strings.TrimSpace(version[:idx])
+	}
 	if !strings.HasPrefix(version, "go") {
 		progress.ItemInfo("Invalid go.dev/VERSION output (using go1.26.0 as fallback)")
 		return "go1.26.0", nil


### PR DESCRIPTION
On Linux, append /usr/local/go/bin to PATH when the go binary exists there so exec.LookPath can find it. Also strip any trailing newline or extra lines from the go.dev/VERSION response before checking the prefix to avoid parsing issues.