### PR TITLE
Add tool timeouts and new tool configs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -127,6 +127,12 @@ type ToolsConfig struct {
 
 	// Dalfox specific settings
 	Dalfox DalfoxConfig `yaml:"dalfox"`
+
+	// Katana specific settings
+	Katana KatanaConfig `yaml:"katana"`
+
+	// GoSpider specific settings
+	GoSpider GoSpiderConfig `yaml:"gospider"`
 }
 
 type SubfinderConfig struct {
@@ -144,7 +150,7 @@ type NucleiConfig struct {
 	ExcludeTags    []string `yaml:"exclude_tags"`    // template tags to exclude (default: [dos, fuzz])
 	Severity       []string `yaml:"severity"`        // severities to scan (default: [low, medium, high, critical])
 	DisableOOB     *bool    `yaml:"disable_oob"`     // disable Interactsh OOB checks — prevents hangs (default: true)
-	MaxTimeout     int      `yaml:"max_timeout_min"` // hard process timeout per Nuclei run in minutes (default: 300)
+	MaxTimeout     int      `yaml:"max_timeout_min"` // hard process timeout per Nuclei run in minutes (default: 180)
 	DASTAggression string   `yaml:"dast_aggression"` // DAST fuzzing payload count: low/medium/high (default: high)
 }
 
@@ -164,12 +170,22 @@ type NaabuConfig struct {
 	Threads int    `yaml:"threads"` // concurrent scanning threads (default: 25)
 	Rate    int    `yaml:"rate"`    // packets per second (default: 1000)
 	Ports   string `yaml:"ports"`   // port spec: "top-1000", "80,443,8080", or range (default: top-1000)
+	Timeout int    `yaml:"timeout"` // max runtime in minutes for Naabu (default: 240)
 }
 
 type FfufConfig struct {
 	Threads    int   `yaml:"threads"`     // concurrent fuzzing threads (default: 50)
 	Timeout    int   `yaml:"timeout"`     // per-request timeout in seconds (default: 10)
 	MatchCodes []int `yaml:"match_codes"` // HTTP status codes to report as findings (default: 200,201,204,301,...)
+	MaxTimeout int   `yaml:"max_timeout_min"` // hard process timeout per ffuf run in minutes (default: 180)
+}
+
+type KatanaConfig struct {
+	Timeout int `yaml:"timeout"` // max runtime in minutes for Katana (default: 300)
+}
+
+type GoSpiderConfig struct {
+	Timeout int `yaml:"timeout"` // max runtime in minutes for GoSpider (default: 300)
 }
 
 type NotificationConfig struct {
@@ -343,7 +359,7 @@ func DefaultConfig() *Config {
 				Severity:       []string{"low", "medium", "high", "critical"},
 				ExcludeTags:    []string{"dos", "fuzz"},
 				DisableOOB:     newBool(true),
-				MaxTimeout:     300,
+				MaxTimeout:     180,
 				DASTAggression: "high",
 			},
 			Httpx: HttpxConfig{
@@ -355,15 +371,23 @@ func DefaultConfig() *Config {
 			Naabu: NaabuConfig{
 				Threads: 25,
 				Rate:    1000,
+				Timeout: 240,
 			},
 			Ffuf: FfufConfig{
 				Threads:    50,
 				Timeout:    10,
 				MatchCodes: []int{200, 201, 204, 301, 302, 307, 401, 403, 405, 500},
+				MaxTimeout: 180,
 			},
 			Dalfox: DalfoxConfig{
 				MaxURLs:        500,
 				SkipThirdParty: newBool(true),
+			},
+			Katana: KatanaConfig{
+				Timeout: 300,
+			},
+			GoSpider: GoSpiderConfig{
+				Timeout: 300,
 			},
 		},
 		Notifications: NotificationConfig{
@@ -403,7 +427,7 @@ func applyDefaults(cfg *Config) {
 	defaultInt(&cfg.General.JSLimit, 2000)
 	defaultInt(&cfg.Tools.Nuclei.Concurrency, 25)
 	defaultInt(&cfg.Tools.Nuclei.RateLimit, 150)
-	defaultInt(&cfg.Tools.Nuclei.MaxTimeout, 300)
+	defaultInt(&cfg.Tools.Nuclei.MaxTimeout, 180)
 	if cfg.Tools.Nuclei.DisableOOB == nil {
 		cfg.Tools.Nuclei.DisableOOB = newBool(true)
 	}
@@ -412,6 +436,10 @@ func applyDefaults(cfg *Config) {
 	if cfg.Tools.Dalfox.SkipThirdParty == nil {
 		cfg.Tools.Dalfox.SkipThirdParty = newBool(true)
 	}
+	defaultInt(&cfg.Tools.Naabu.Timeout, 240)
+	defaultInt(&cfg.Tools.Ffuf.MaxTimeout, 180)
+	defaultInt(&cfg.Tools.Katana.Timeout, 300)
+	defaultInt(&cfg.Tools.GoSpider.Timeout, 300)
 	defaultString(&cfg.Notifications.MinSeverity, "high")
 
 	// Proxy scraping defaults

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -428,6 +428,34 @@ func (t *ToolBox) ffufMatchCodes() string {
 	return "200,201,204,301,302,307,401,403,405,500"
 }
 
+func (t *ToolBox) naabuMaxTimeout() time.Duration {
+	if t.Config != nil && t.Config.Naabu.Timeout > 0 {
+		return time.Duration(t.Config.Naabu.Timeout) * time.Minute
+	}
+	return 240 * time.Minute
+}
+
+func (t *ToolBox) ffufMaxTimeout() time.Duration {
+	if t.Config != nil && t.Config.Ffuf.MaxTimeout > 0 {
+		return time.Duration(t.Config.Ffuf.MaxTimeout) * time.Minute
+	}
+	return 180 * time.Minute
+}
+
+func (t *ToolBox) katanaMaxTimeout() time.Duration {
+	if t.Config != nil && t.Config.Katana.Timeout > 0 {
+		return time.Duration(t.Config.Katana.Timeout) * time.Minute
+	}
+	return 300 * time.Minute
+}
+
+func (t *ToolBox) goSpiderMaxTimeout() time.Duration {
+	if t.Config != nil && t.Config.GoSpider.Timeout > 0 {
+		return time.Duration(t.Config.GoSpider.Timeout) * time.Minute
+	}
+	return 300 * time.Minute
+}
+
 // --- Passive Enumeration ---
 
 func (t *ToolBox) RunSubfinder(ctx context.Context, domain string, outputFile string) error {
@@ -557,7 +585,7 @@ func (t *ToolBox) RunNaabu(ctx context.Context, host string, outputFile string) 
 		args = append(args, "-top-ports", strconv.Itoa(t.naabuTopPorts()))
 	}
 	args = t.appendProxy(args, "-proxy")
-	_, err := t.Runner.Run(ctx, "naabu", args)
+	_, err := t.Runner.Run(ctx, "naabu", args, runner.WithTimeout(t.naabuMaxTimeout()))
 	return err
 }
 
@@ -585,7 +613,7 @@ func (t *ToolBox) RunNaabuList(ctx context.Context, inputFile string, outputFile
 		args = append(args, "-top-ports", strconv.Itoa(t.naabuTopPorts()))
 	}
 	args = t.appendProxy(args, "-proxy")
-	_, err := t.Runner.Run(ctx, "naabu", args)
+	_, err := t.Runner.Run(ctx, "naabu", args, runner.WithTimeout(t.naabuMaxTimeout()))
 	return err
 }
 
@@ -594,7 +622,7 @@ func (t *ToolBox) RunNaabuList(ctx context.Context, inputFile string, outputFile
 func (t *ToolBox) RunGoSpider(ctx context.Context, inputFile string, outputFile string) error {
 	args := []string{"-S", inputFile, "-q", "-c", "10", "-d", "3", "-t", "10"} // -t = per-request timeout (seconds)
 	args = t.appendGoSpiderUA(args)
-	output, err := t.Runner.Run(ctx, "gospider", args)
+	output, err := t.Runner.Run(ctx, "gospider", args, runner.WithTimeout(t.goSpiderMaxTimeout()))
 	if strings.TrimSpace(output) != "" {
 		if writeErr := writeToFile(outputFile, output); writeErr != nil {
 			return writeErr
@@ -626,7 +654,7 @@ func (t *ToolBox) RunKatana(ctx context.Context, inputFile string, outputFile st
 	if rps := t.globalRPS(); rps > 0 {
 		args = append(args, "-rate-limit", strconv.Itoa(rps))
 	}
-	_, err := t.Runner.Run(ctx, "katana", args)
+	_, err := t.Runner.Run(ctx, "katana", args, runner.WithTimeout(t.katanaMaxTimeout()))
 	return err
 }
 
@@ -652,7 +680,7 @@ func (t *ToolBox) RunFfuf(ctx context.Context, url string, wordlist string, outp
 	if rps := t.globalRPS(); rps > 0 {
 		args = append(args, "-rate", strconv.Itoa(rps))
 	}
-	_, err := t.Runner.Run(ctx, "ffuf", args)
+	_, err := t.Runner.Run(ctx, "ffuf", args, runner.WithTimeout(t.ffufMaxTimeout()))
 	return err
 }
 
@@ -684,7 +712,7 @@ func (t *ToolBox) RunFfufWithFUZZ(ctx context.Context, baseURL string, wordlist 
 	if rps := t.globalRPS(); rps > 0 {
 		args = append(args, "-rate", strconv.Itoa(rps))
 	}
-	_, err := t.Runner.Run(ctx, "ffuf", args)
+	_, err := t.Runner.Run(ctx, "ffuf", args, runner.WithTimeout(t.ffufMaxTimeout()))
 	return err
 }
 


### PR DESCRIPTION
Introduce configurable timeouts for several tools and wire them into the runner. Added KatanaConfig and GoSpiderConfig plus Naabu.Timeout and Ffuf.MaxTimeout fields in the config, with defaults set in DefaultConfig/applyDefaults. Reduced Nuclei default MaxTimeout from 300 to 180 minutes. Implemented ToolBox helper methods to compute timeouts and applied runner.WithTimeout to Naabu, GoSpider, Katana and Ffuf invocations so processes respect configured limits.